### PR TITLE
Added dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,8 @@ setup(
     author = 'Mollie B.V.',
     author_email = 'info@mollie.nl',
     keywords = ['mollie', 'payment', 'service', 'ideal', 'creditcard', 'mistercash', 'bancontact', 'sofort', 'sofortbanking', 'sepa', 'bitcoin', 'paypal', 'paysafecard', 'banktransfer', 'direct debit', 'belfius', 'belfius direct net', 'refunds', 'payments', 'gateway'],
-    url = 'https://github.com/mollie/mollie-api-python'
+    url = 'https://github.com/mollie/mollie-api-python',
+    install_requires=[
+        'requests',
+    ],
 )


### PR DESCRIPTION
I've added requests as required install/dependency. Maybe there is a reason why requests was not added as dependency in the first place? A reason could be to not interfere with the requests version used in the same project as the one where the Mollie client is being/going to be used.

If no reason for this, I'd like this pull request to be merged into master.