### PR TITLE
Added support for kwargs for POST requests.

### DIFF
--- a/Mollie/API/Resource/Base.py
+++ b/Mollie/API/Resource/Base.py
@@ -46,7 +46,8 @@ class Base(object):
         result = self.performApiCall(self.REST_LIST, path, None, params)
         return List(result, self.getResourceObject({}).__class__)
 
-    def create(self, data=None):
+    def create(self, data=None, **params):
+        data = self.merge_dictionaries(data, params)
         if data is not None:
             try:
                 data = json.dumps(data)
@@ -57,11 +58,13 @@ class Base(object):
     def get(self, resource_id, **params):
         return self.rest_read(resource_id, params)
 
-    def update(self, resource_id, data):
-        try:
-            data = json.dumps(data)
-        except Exception as e:
-            raise Error('Error encoding parameters into JSON: "%s"' % str(e))
+    def update(self, resource_id, data=None, **params):
+        data = self.merge_dictionaries(data, params)
+        if data is not None:
+            try:
+                data = json.dumps(data)
+            except Exception as e:
+                raise Error('Error encoding parameters into JSON: "%s"' % str(e))
         return self.rest_update(resource_id, data)
 
     def delete(self, resource_id):
@@ -69,6 +72,20 @@ class Base(object):
 
     def all(self, **params):
         return self.rest_list(params)
+
+    @staticmethod
+    def merge_dictionaries(a, b):
+        if a is None and b is None:
+            return None
+        if a is None:
+            return b
+        if b is None:
+            return a
+
+        merged_dict = a.copy()
+        merged_dict.update(b)
+
+        return merged_dict
 
     def performApiCall(self, http_method, path, data=None, params=None):
         body = self.client.performHttpCall(http_method, path, data, params)

--- a/Mollie/API/Resource/Payments.py
+++ b/Mollie/API/Resource/Payments.py
@@ -22,5 +22,5 @@ class Payments(Base):
     def chargebacks(self, payment):
         return self.client.payment_chargebacks.on(payment)
 
-    def refund(self, payment, data=None):
-        return self.refunds(payment).create(data)
+    def refund(self, payment, data=None, **params):
+        return self.refunds(payment).create(data, **params)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mollie-api-python',
-    version='1.3.0',
+    version='1.3.1',
     license='BSD',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
**Introduction**
This Pull Request equalizes the behavior for providing data to GET and POST requests. Up until now, the method of providing data to POST requests was limited to providing a dictionary with data as argument or keyword argument. GET requests can make use of keyword argument fields, however.

To put this more into perspective, making a call that initiates a POST request was done like the following:
```
client = Mollie.API.Client()
client.payments.refund(payment, {"amount": 10})
```
And making a call that initiates a GET request was done like the following:
```
client.payments.all(count=20)
```

**Changes**
So, to improve this behavior, it is now possible to add keyword argument fields to POST request calls. This data is then combined with the 'data' dictionary. Both methods are supported, because sometimes it is more convenient to just provide a dictionary of data instead of single fields (think when creating payment).

This also means it is backwards compatible, and both ways of providing data for a POST request can be mixed.