### PR TITLE
Add support for query string parameters for POST requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.6"
 
 install:
+  - pip install --upgrade pip setuptools
   - pip install pipenv
   - pipenv install --dev
 

--- a/Mollie/API/Client.py
+++ b/Mollie/API/Client.py
@@ -6,14 +6,12 @@ import pkg_resources
 
 import requests
 
-from .Error import Error
+from . import Error
+from . import Resource
 
 
 class Client(object):
     CLIENT_VERSION = '1.2.1'
-    HTTP_GET       = 'GET'
-    HTTP_POST      = 'POST'
-    HTTP_DELETE    = 'DELETE'
     API_ENDPOINT   = 'https://api.mollie.nl'
     API_VERSION    = 'v1'
     UNAME          = ' '.join(platform.uname())
@@ -35,8 +33,6 @@ class Client(object):
         return api_key
 
     def __init__(self, api_key=None, api_endpoint=None):
-        from . import Resource
-
         self.api_endpoint = self.validateApiEndpoint(api_endpoint or self.API_ENDPOINT)
         self.api_version = self.API_VERSION
         self.api_key = self.validateApiKey(api_key) if api_key else None

--- a/Mollie/API/Resource/Base.py
+++ b/Mollie/API/Resource/Base.py
@@ -1,16 +1,15 @@
-from Mollie.API.Client import Client
-from Mollie.API.Error import Error
-from Mollie.API.Object import List
-
 import json
+
+from Mollie.API import Error
+from Mollie.API.Object import List
 
 
 class Base(object):
-    REST_CREATE = Client.HTTP_POST
-    REST_UPDATE = Client.HTTP_POST
-    REST_READ = Client.HTTP_GET
-    REST_LIST = Client.HTTP_GET
-    REST_DELETE = Client.HTTP_DELETE
+    REST_CREATE = 'POST'
+    REST_UPDATE = 'POST'
+    REST_READ = 'GET'
+    REST_LIST = 'GET'
+    REST_DELETE = 'DELETE'
     DEFAULT_LIMIT = 10
 
     def __init__(self, client):
@@ -29,7 +28,7 @@ class Base(object):
 
     def rest_read(self, resource_id, params=None):
         path = self.getResourceName() + '/' + str(resource_id)
-        result = self.performApiCall(self.REST_READ, path, None, params)
+        result = self.performApiCall(self.REST_READ, path, params=params)
         return self.getResourceObject(result)
 
     def rest_update(self, resource_id, data, params=None):
@@ -39,53 +38,37 @@ class Base(object):
 
     def rest_delete(self, resource_id, params=None):
         path = self.getResourceName() + '/' + str(resource_id)
-        return self.performApiCall(self.REST_DELETE, path, None, params)
+        return self.performApiCall(self.REST_DELETE, path, params=params)
 
     def rest_list(self, params=None):
         path = self.getResourceName()
-        result = self.performApiCall(self.REST_LIST, path, None, params)
+        result = self.performApiCall(self.REST_LIST, path, params=params)
         return List(result, self.getResourceObject({}).__class__)
 
     def create(self, data=None, **params):
-        data = self.merge_dictionaries(data, params)
         if data is not None:
             try:
                 data = json.dumps(data)
             except Exception as e:
                 raise Error('Error encoding parameters into JSON: "%s"' % str(e))
-        return self.rest_create(data)
+        return self.rest_create(data, params)
 
     def get(self, resource_id, **params):
         return self.rest_read(resource_id, params)
 
     def update(self, resource_id, data=None, **params):
-        data = self.merge_dictionaries(data, params)
         if data is not None:
             try:
                 data = json.dumps(data)
             except Exception as e:
                 raise Error('Error encoding parameters into JSON: "%s"' % str(e))
-        return self.rest_update(resource_id, data)
+        return self.rest_update(resource_id, data, params)
 
     def delete(self, resource_id):
         return self.rest_delete(resource_id)
 
     def all(self, **params):
         return self.rest_list(params)
-
-    @staticmethod
-    def merge_dictionaries(a, b):
-        if a is None and b is None:
-            return None
-        if a is None:
-            return b
-        if b is None:
-            return a
-
-        merged_dict = a.copy()
-        merged_dict.update(b)
-
-        return merged_dict
 
     def performApiCall(self, http_method, path, data=None, params=None):
         body = self.client.performHttpCall(http_method, path, data, params)

--- a/Mollie/API/__init__.py
+++ b/Mollie/API/__init__.py
@@ -1,6 +1,6 @@
 __all__ = ["Object", "Resource", "Error", "Client"]
 
-from . import Object
-from . import Resource
 from .Error import Error
 from .Client import Client
+from . import Object
+from . import Resource

--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ if payment.isPaid():
     print 'Payment received.'
 ```
 
+### How to pass the different parameter types ###
+In the example above, a new payment is created by passing a dictionary of payment data, which corresponds to the `data` parameter of the `mollie.payments.create` method. This data will be used as request body in a POST request to Mollie. In general, the methods for POST requests, which accept request body parameters, have a `data` parameter to provide such request body parameters.
+
+Every keyword argument (other than `data`) passed to a method will be interpreted as a query string parameter. For example, the following method call:
+```python
+payments = mollie.payments.all(count=20)
+```
+Will result in a request with query string `?count=20`. Furthermore, this is an example of a request that only accepts query string parameters. Both can be combined, however, to for example create a payment that includes a QR code object:
+```python
+payment = mollie.payments.create(
+    {
+        'amount': 10.00,
+        'description': 'My first API payment',
+        'redirectUrl': 'https://webshop.example.org/order/12345/',
+        'webhookUrl': 'https://webshop.example.org/mollie-webhook/',
+        'method': Method.IDEAL
+    },
+    include='details.qrCode'
+)
+```
+
 ### Fully integrated iDEAL payments ###
 
 If you want to fully integrate iDEAL payments in your web site, some additional steps are required. First, you need to

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mollie-api-python',
-    version='1.3.2',
+    version='1.4.0',
     license='BSD',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
As noted in #38, it is not clear how, and even worse, not possible to provide query string parameters in requests methods that accept request body parameters (POST requests).

Previously I had implemented that request body parameters could be passed by both a dictionary and keyword arguments. But now it is clear that I had overlooked that POST requests could also have query parameters. So, I have reverted those changes and added that query string parameters can be added to POST request methods as keyword arguments.

To make it totally clear, the following is now default behavior throughout the client:
- For requests that accept request body parameters (POST requests), the `data` parameter can be used to supply a dictionary of request body parameters to the method. In a lot of those methods, it is the first parameter.
- For requests that accept query string parameters, keyword arguments can be used to supply those to the method.
- A combination of those two of course be used if applicable.

I have also added explanation with examples in README.md. Please note that these changes are breaking, as using keyword arguments for request body parameters will no longer work.

Some unrelated changes:
- Modified import statements such that the `from . import Resource` import in `Mollie.API.Client` no longer has to be done inside the `__init__` method.
- Removed redundant constants from `Mollie.API.Client`.