### PR TITLE
Implement Base._get_link() and use it

### DIFF
--- a/mollie/api/objects/base.py
+++ b/mollie/api/objects/base.py
@@ -5,3 +5,10 @@ class Base(dict):
         if name not in self:
             return None
         return self[name]
+
+    def _get_link(self, name):
+        """Return a link by its name."""
+        try:
+            return self['_links'][name]['href']
+        except KeyError:
+            return None

--- a/mollie/api/objects/customer.py
+++ b/mollie/api/objects/customer.py
@@ -37,33 +37,27 @@ class Customer(Base):
 
     @property
     def subscriptions(self):
-        """Return subscription object from the links attribute."""
+        """Return the subscription list for the customer."""
         from .subscription import Subscription
-        try:
-            url = self['_links']['subscriptions']['href']
-        except KeyError:
-            return None
-        resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-        return List(resp, Subscription)
+        url = self._get_link('subscriptions')
+        if url:
+            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
+            return List(resp, Subscription)
 
     @property
     def mandates(self):
-        """Return the mandate list referenced in the _links."""
+        """Return the mandate list for the customer."""
         from .mandate import Mandate  # work around circular import
-        try:
-            url = self['_links']['mandates']['href']
-        except KeyError:
-            return None
-        resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-        return List(resp, Mandate)
+        url = self._get_link('mandates')
+        if url:
+            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
+            return List(resp, Mandate)
 
     @property
     def payments(self):
-        """Return the payment list referenced in the _links."""
+        """Return the payment list for the customer."""
         from .payment import Payment  # work around circular import
-        try:
-            url = self['_links']['payments']['href']
-        except KeyError:
-            return None
-        resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-        return List(resp, Payment)
+        url = self._get_link('payments')
+        if url:
+            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
+            return List(resp, Payment)

--- a/mollie/api/objects/customer.py
+++ b/mollie/api/objects/customer.py
@@ -37,7 +37,7 @@ class Customer(Base):
 
     @property
     def subscriptions(self):
-        """Return subscription object from the links attribute"""
+        """Return subscription object from the links attribute."""
         from .subscription import Subscription
         try:
             url = self['_links']['subscriptions']['href']

--- a/mollie/api/objects/mandate.py
+++ b/mollie/api/objects/mandate.py
@@ -39,21 +39,22 @@ class Mandate(Base):
         return self._get_property('createdAt')
 
     def is_pending(self):
+        """Check if the mandate is pending."""
         return self.status == self.STATUS_PENDING
 
     def is_valid(self):
+        """Check if the mandate is valid."""
         return self.status == self.STATUS_VALID
 
     def is_invalid(self):
+        """Check if the mandate is invalid."""
         return self.status == self.STATUS_INVALID
 
     @property
     def customer(self):
-        """Return the customer referenced in the _links."""
+        """Return the customer for this mandate."""
         from .customer import Customer  # work around circular imports
-        try:
-            url = self['_links']['customer']['href']
-        except KeyError:
-            return None
-        resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-        return Customer(resp)
+        url = self._get_link('customer')
+        if url:
+            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
+            return Customer(resp)

--- a/mollie/api/objects/method.py
+++ b/mollie/api/objects/method.py
@@ -48,7 +48,7 @@ class Method(Base):
 
     @property
     def issuers(self):
-        """Return the issuer list."""
+        """Return the list of available issuers for this payment method."""
         issuers = self._get_property('issuers') or []
         result = {
             '_embedded': {

--- a/mollie/api/objects/payment.py
+++ b/mollie/api/objects/payment.py
@@ -146,6 +146,7 @@ class Payment(Base):
 
     @property
     def refunds(self):
+        """Return the refunds related to this payment."""
         from .refund import Refund
         url = self._get_link('refunds')
         if url:
@@ -154,6 +155,7 @@ class Payment(Base):
 
     @property
     def chargebacks(self):
+        """Return the chargebacks related to this payment."""
         from .chargeback import Chargeback
         url = self._get_link('chargebacks')
         if url:
@@ -162,6 +164,7 @@ class Payment(Base):
 
     @property
     def customer(self):
+        """Return the customer for this payment."""
         from .customer import Customer
         url = self._get_link('customer')
         if url:

--- a/mollie/api/objects/payment.py
+++ b/mollie/api/objects/payment.py
@@ -38,6 +38,12 @@ class Payment(Base):
         except KeyError:
             return False
 
+    def can_be_refunded(self):
+        try:
+            return self._get_property('amountRemaining') is not None
+        except KeyError:
+            return False
+
     def has_sequence_type_first(self):
         return self._get_property('sequenceType') == self.SEQUENCETYPE_FIRST
 
@@ -138,13 +144,6 @@ class Payment(Base):
     @property
     def customer_id(self):
         return self._get_property('customerId')
-
-    @property
-    def can_be_refunded(self):
-        try:
-            return self._get_property('amountRemaining') is not None
-        except KeyError:
-            return False
 
     @property
     def amount_refunded(self):

--- a/mollie/api/objects/payment.py
+++ b/mollie/api/objects/payment.py
@@ -33,16 +33,10 @@ class Payment(Base):
         return self._get_property('status') == self.STATUS_FAILED
 
     def has_refunds(self):
-        try:
-            return self['_links']['refunds'] is not None
-        except KeyError:
-            return False
+        return self._get_link('refunds') is not None
 
     def can_be_refunded(self):
-        try:
-            return self._get_property('amountRemaining') is not None
-        except KeyError:
-            return False
+        return self._get_property('amountRemaining') is not None
 
     def has_sequence_type_first(self):
         return self._get_property('sequenceType') == self.SEQUENCETYPE_FIRST
@@ -52,10 +46,7 @@ class Payment(Base):
 
     @property
     def checkout_url(self):
-        try:
-            return self['_links']['checkout']['href']
-        except KeyError:
-            return None
+        return self._get_link('checkout')
 
     @property
     def resource(self):
@@ -156,29 +147,23 @@ class Payment(Base):
     @property
     def refunds(self):
         from .refund import Refund
-        try:
-            url = self['_links']['refunds']['href']
-        except KeyError:
-            return None
-        resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-        return List(resp, Refund)
+        url = self._get_link('refunds')
+        if url:
+            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
+            return List(resp, Refund)
 
     @property
     def chargebacks(self):
         from .chargeback import Chargeback
-        try:
-            url = self['_links']['chargebacks']['href']
-        except KeyError:
-            return None
-        resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-        return List(resp, Chargeback)
+        url = self._get_link('chargebacks')
+        if url:
+            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
+            return List(resp, Chargeback)
 
     @property
     def customer(self):
         from .customer import Customer
-        try:
-            url = self['_links']['customer']['href']
-        except KeyError:
-            return None
-        resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-        return Customer(resp)
+        url = self._get_link('customer')
+        if url:
+            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
+            return Customer(resp)

--- a/mollie/api/objects/subscription.py
+++ b/mollie/api/objects/subscription.py
@@ -79,9 +79,7 @@ class Subscription(Base):
     @property
     def customer(self):
         """Return customer object from the links attribute."""
-        try:
-            url = self['_links']['customer']['href']
-        except KeyError:
-            return None
-        resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-        return Customer(resp)
+        url = self._get_link('customer')
+        if url:
+            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
+            return Customer(resp)

--- a/mollie/api/objects/subscription.py
+++ b/mollie/api/objects/subscription.py
@@ -78,7 +78,7 @@ class Subscription(Base):
 
     @property
     def customer(self):
-        """Return customer object from the links attribute."""
+        """Return the customer for this subscription."""
         url = self._get_link('customer')
         if url:
             resp = self._resource.perform_api_call(self._resource.REST_READ, url)

--- a/tests/responses/payment_single.json
+++ b/tests/responses/payment_single.json
@@ -35,7 +35,7 @@
       "type": "application/json"
     },
     "refunds": {
-      "href": "https://api.mollie.com/v2/payments/tr_7UhSN1zuXS/refunds/re_4qqhO89gsT",
+      "href": "https://api.mollie.com/v2/payments/tr_7UhSN1zuXS/refunds",
       "type": "application/json"
     },
     "customer": {

--- a/tests/test_chargebacks.py
+++ b/tests/test_chargebacks.py
@@ -7,8 +7,8 @@ def test_get_all_chargebacks(client, response):
     response.get('https://api.mollie.com/v2/chargebacks', 'chargebacks_list')
 
     chargebacks = client.chargebacks.all()
-    assert chargebacks.count == 1
     assert isinstance(chargebacks, List)
+    assert chargebacks.count == 1
 
     iterated = 0
     iterated_chargeback_ids = []

--- a/tests/test_customer_mandates.py
+++ b/tests/test_customer_mandates.py
@@ -30,6 +30,7 @@ def test_get_customer_mandate_by_id(client, response):
         'https://api.mollie.com/v2/customers/%s/mandates/%s' % (CUSTOMER_ID, MANDATE_ID),
         'customer_mandate_single',
     )
+    response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_new')
 
     mandate = client.customer_mandates.with_parent_id(CUSTOMER_ID).get(MANDATE_ID)
     assert mandate.id == MANDATE_ID
@@ -47,6 +48,7 @@ def test_get_customer_mandate_by_id(client, response):
     assert mandate.is_pending() is False
     assert mandate.is_valid() is True
     assert mandate.is_invalid() is False
+    assert mandate.customer is not None
 
 
 def test_get_customer_mandate_by_customer(client, response):

--- a/tests/test_customer_mandates.py
+++ b/tests/test_customer_mandates.py
@@ -33,6 +33,7 @@ def test_get_customer_mandate_by_id(client, response):
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_new')
 
     mandate = client.customer_mandates.with_parent_id(CUSTOMER_ID).get(MANDATE_ID)
+    assert isinstance(mandate, Mandate)
     assert mandate.id == MANDATE_ID
     assert mandate.resource == 'mandate'
     assert mandate.status == 'valid'
@@ -65,6 +66,7 @@ def test_get_customer_mandate_by_customer(client, response):
     assert MANDATE_ID in [x.id for x in mandates]
 
     mandate = client.customer_mandates.on(customer).get(MANDATE_ID)
+    assert isinstance(mandate, Mandate)
     assert mandate.id == MANDATE_ID
 
 
@@ -94,6 +96,7 @@ def test_customer_mandates_create_mandate(client, response):
         'mandateReference': 'YOUR-COMPANY-MD1380',
     }
     mandate = client.customer_mandates.with_parent_id(CUSTOMER_ID).create(data=data)
+    assert isinstance(mandate, Mandate)
     assert mandate.id == MANDATE_ID
 
 
@@ -112,4 +115,5 @@ def test_update_customer_mandate(client, response):
         'mandateReference': 'OTHER-COMPANY-12345',
     }
     mandate = client.customer_mandates.with_parent_id(CUSTOMER_ID).update(MANDATE_ID, data=data)
+    assert isinstance(mandate, Mandate)
     assert mandate.id == MANDATE_ID

--- a/tests/test_customer_payments.py
+++ b/tests/test_customer_payments.py
@@ -14,9 +14,9 @@ def test_get_all_customer_payments(client, response):
     iterated = 0
     iterated_payment_ids = []
     for payment in payments:
-        iterated += 1
         assert isinstance(payment, Payment)
         assert payment.id is not None
+        iterated += 1
         iterated_payment_ids.append(payment.id)
     assert iterated == payments.count, 'Unexpected amount of payments retrieved'
     assert len(set(iterated_payment_ids)) == payments.count, 'Unexpected unique payment ids retrieved'
@@ -34,4 +34,5 @@ def test_create_customer_payment(client, response):
             'webhookUrl': 'https://webshop.example.org/payments/webhook/',
             'method': 'ideal',
         })
+    assert isinstance(payment, Payment)
     assert payment.customer_id == CUSTOMER_ID

--- a/tests/test_customer_payments.py
+++ b/tests/test_customer_payments.py
@@ -5,7 +5,7 @@ CUSTOMER_ID = 'cst_8wmqcHMN4U'
 
 
 def test_get_all_customer_payments(client, response):
-    """Retrieve a list of payments related to a customer id"""
+    """Retrieve a list of payments related to a customer id."""
     response.get('https://api.mollie.com/v2/customers/%s/payments' % CUSTOMER_ID, 'customer_payments_multiple')
 
     payments = client.customer_payments.with_parent_id(CUSTOMER_ID).all()
@@ -23,7 +23,7 @@ def test_get_all_customer_payments(client, response):
 
 
 def test_create_customer_payment(client, response):
-    """Create a customer payment"""
+    """Create a customer payment."""
     response.post('https://api.mollie.com/v2/customers/%s/payments' % CUSTOMER_ID, 'payment_single')
 
     payment = client.customer_payments.with_parent_id(CUSTOMER_ID).create(

--- a/tests/test_customer_subscriptions.py
+++ b/tests/test_customer_subscriptions.py
@@ -7,7 +7,7 @@ SUBSCRIPTION_ID = 'sub_rVKGtNd6s3'
 
 
 def test_customer_subscriptions_all(client, response):
-    """Retrieve a list of subscriptions"""
+    """Retrieve a list of subscriptions."""
     response.get('https://api.mollie.com/v2/customers/%s/subscriptions' % CUSTOMER_ID, 'subscriptions_list')
 
     subscriptions = client.customer_subscriptions.with_parent_id(CUSTOMER_ID).all()
@@ -26,7 +26,7 @@ def test_customer_subscriptions_all(client, response):
 
 
 def test_get_customer_subscription_by_id(client, response):
-    """Retrieve a single subscription by ID """
+    """Retrieve a single subscription by ID."""
     response.get('https://api.mollie.com/v2/customers/%s/subscriptions/%s' % (CUSTOMER_ID, SUBSCRIPTION_ID),
                  'subscription_single')
 
@@ -50,7 +50,7 @@ def test_get_customer_subscription_by_id(client, response):
 
 
 def test_get_all_customer_subscriptions_by_customer_object(client, response):
-    """Retrieve all subscriptions related to customer"""
+    """Retrieve all subscriptions related to customer."""
     response.get('https://api.mollie.com/v2/customers/%s/subscriptions' % CUSTOMER_ID,
                  'subscriptions_list')
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_single')
@@ -67,7 +67,7 @@ def test_get_all_customer_subscriptions_by_customer_object(client, response):
 
 
 def test_get_one_customer_subscription_by_customer_object(client, response):
-    """Retrieve specific subscription related to customer"""
+    """Retrieve specific subscription related to customer."""
     response.get('https://api.mollie.com/v2/customers/%s/subscriptions/%s' % (CUSTOMER_ID, SUBSCRIPTION_ID),
                  'subscription_single')
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_single')
@@ -79,7 +79,7 @@ def test_get_one_customer_subscription_by_customer_object(client, response):
 
 
 def test_customer_subscription_get_related_customer(client, response):
-    """Retrieve a related customer object from a subscription"""
+    """Retrieve a related customer object from a subscription."""
     response.get('https://api.mollie.com/v2/customers/%s/subscriptions/%s' % (CUSTOMER_ID, SUBSCRIPTION_ID),
                  'subscription_single')
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_single')
@@ -90,7 +90,7 @@ def test_customer_subscription_get_related_customer(client, response):
 
 
 def test_cancel_customer_subscription(client, response):
-    """Cancel a subscription by customer ID and subscription ID"""
+    """Cancel a subscription by customer ID and subscription ID."""
     response.delete('https://api.mollie.com/v2/customers/%s/subscriptions/%s' % (CUSTOMER_ID, SUBSCRIPTION_ID),
                     'subscription_canceled', 200)
 
@@ -100,7 +100,7 @@ def test_cancel_customer_subscription(client, response):
 
 
 def test_create_customer_subscription(client, response):
-    """create a subscription with customer object"""
+    """Create a subscription with customer object."""
     response.post('https://api.mollie.com/v2/customers/%s/subscriptions' % CUSTOMER_ID, 'subscription_single')
     data = {
         'amount': {'currency': 'EUR', 'value': '25.00'},
@@ -114,7 +114,7 @@ def test_create_customer_subscription(client, response):
 
 
 def test_update_customer_subscription(client, response):
-    """Update existing subscription of a customer"""
+    """Update existing subscription of a customer."""
     response.patch('https://api.mollie.com/v2/customers/%s/subscriptions/%s' % (CUSTOMER_ID, SUBSCRIPTION_ID),
                    'subscription_updated')
 

--- a/tests/test_customer_subscriptions.py
+++ b/tests/test_customer_subscriptions.py
@@ -18,8 +18,8 @@ def test_customer_subscriptions_all(client, response):
     iterated_subscription_ids = []
     for subscription in subscriptions:
         assert isinstance(subscription, Subscription)
-        iterated += 1
         assert subscription.id is not None
+        iterated += 1
         iterated_subscription_ids.append(subscription.id)
     assert iterated == subscriptions.count, 'Unexpected amount of subscriptions retrieved'
     assert len(set(iterated_subscription_ids)) == subscriptions.count, \
@@ -79,8 +79,8 @@ def test_get_one_customer_subscription_by_customer_object(client, response):
 
     customer = client.customers.get(CUSTOMER_ID)
     subscription = client.customer_subscriptions.on(customer).get(SUBSCRIPTION_ID)
-    assert subscription.customer.id == CUSTOMER_ID
     assert isinstance(subscription, Subscription)
+    assert subscription.customer.id == CUSTOMER_ID
 
 
 def test_customer_subscription_get_related_customer(client, response):
@@ -108,6 +108,7 @@ def test_cancel_customer_subscription(client, response):
 def test_create_customer_subscription(client, response):
     """Create a subscription with customer object."""
     response.post('https://api.mollie.com/v2/customers/%s/subscriptions' % CUSTOMER_ID, 'subscription_single')
+
     data = {
         'amount': {'currency': 'EUR', 'value': '25.00'},
         'times': 4,
@@ -116,6 +117,7 @@ def test_create_customer_subscription(client, response):
         'webhookUrl': 'https://webshop.example.org/subscriptions/webhook'
     }
     subscription = client.customer_subscriptions.with_parent_id(CUSTOMER_ID).create(data=data)
+    assert isinstance(subscription, Subscription)
     assert subscription.id == SUBSCRIPTION_ID
 
 
@@ -132,4 +134,5 @@ def test_update_customer_subscription(client, response):
         'webhookUrl': 'https://webshop.example.org/subscriptions/webhook'
     }
     subscription = client.customer_subscriptions.with_parent_id(CUSTOMER_ID).update(SUBSCRIPTION_ID, data)
+    assert isinstance(subscription, Subscription)
     assert subscription.id == SUBSCRIPTION_ID

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -61,15 +61,21 @@ def test_customers_all(client, response):
 def test_customer_get(client, response):
     """Retrieve a single customer."""
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_new')
+    response.get('https://api.mollie.com/v2/customers/%s/payments' % CUSTOMER_ID, 'customer_payments_multiple')
+
     customer = client.customers.get(CUSTOMER_ID)
     assert isinstance(customer, Customer)
     assert customer.id == CUSTOMER_ID
     assert customer.name == 'Customer A'
     assert customer.email == 'customer@example.org'
-    assert customer.created_at == '2018-04-06T13:10:19.0Z'
-    assert customer.metadata == {'orderId': '12345'}
     assert customer.locale == 'nl_NL'
+    assert customer.metadata == {'orderId': '12345'}
     assert customer.mode == 'test'
+    assert customer.resource == 'customer'
+    assert customer.created_at == '2018-04-06T13:10:19.0Z'
+    assert customer.subscriptions is None
+    assert customer.mandates is None
+    assert customer.payments is not None
 
 
 def test_customer_get_related_mandates(client, response):
@@ -89,9 +95,9 @@ def test_customer_get_related_mandates(client, response):
 
 def test_customer_get_related_subscriptions(client, response):
     """Retrieve related subscriptions for a customer."""
+    response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_single')
     response.get('https://api.mollie.com/v2/customers/%s/subscriptions' % CUSTOMER_ID,
                  'subscriptions_list')
-    response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_single')
 
     customer = client.customers.get(CUSTOMER_ID)
     subscriptions = customer.subscriptions
@@ -113,6 +119,7 @@ def test_customer_get_related_payments(client, response):
     payments = customer.payments
     assert isinstance(payments, List)
     assert payments.count == 1
+
     iterated = 0
     iterated_payment_ids = []
     for payment in payments:

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -28,6 +28,7 @@ def test_update_customer(client, response):
         'name': 'Updated Customer A',
         'email': 'updated-customer@example.org',
     })
+    assert isinstance(updated_customer, Customer)
     assert updated_customer.name == 'Updated Customer A'
     assert updated_customer.email == 'updated-customer@example.org'
 
@@ -51,8 +52,8 @@ def test_customers_all(client, response):
     iterated_customer_ids = []
     for customer in customers:
         assert isinstance(customer, Customer)
-        iterated += 1
         assert customer.id is not None
+        iterated += 1
         iterated_customer_ids.append(customer.id)
     assert iterated == customers.count, 'Unexpected amount of customers retrieved'
     assert len(set(iterated_customer_ids)) == customers.count, 'Unexpected amount of unique customer ids retrieved'

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -21,7 +21,7 @@ def test_create_customer(client, response):
 
 
 def test_update_customer(client, response):
-    """Update an existing customer"""
+    """Update an existing customer."""
     response.patch('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_updated')
 
     updated_customer = client.customers.update(CUSTOMER_ID, {
@@ -33,7 +33,7 @@ def test_update_customer(client, response):
 
 
 def test_delete_customers(client, response):
-    """Delete a customer"""
+    """Delete a customer."""
     response.delete('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'empty')
 
     deleted_customer = client.customers.delete('cst_8wmqcHMN4U')
@@ -41,7 +41,7 @@ def test_delete_customers(client, response):
 
 
 def test_customers_all(client, response):
-    """Retrieve a list of all existing customers"""
+    """Retrieve a list of all existing customers."""
     response.get('https://api.mollie.com/v2/customers', 'customers_list')
 
     customers = client.customers.all()
@@ -88,7 +88,7 @@ def test_customer_get_related_mandates(client, response):
 
 
 def test_customer_get_related_subscriptions(client, response):
-    """Retrieve related subscriptions for a customer"""
+    """Retrieve related subscriptions for a customer."""
     response.get('https://api.mollie.com/v2/customers/%s/subscriptions' % CUSTOMER_ID,
                  'subscriptions_list')
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_single')
@@ -105,7 +105,7 @@ def test_customer_get_related_subscriptions(client, response):
 
 
 def test_customer_get_related_payments(client, response):
-    """Retrieve related payments for a customer"""
+    """Retrieve related payments for a customer."""
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_new')
     response.get('https://api.mollie.com/v2/customers/%s/payments' % CUSTOMER_ID, 'customer_payments_multiple')
 

--- a/tests/test_issuers.py
+++ b/tests/test_issuers.py
@@ -1,18 +1,20 @@
+from mollie.api.objects.issuer import Issuer
+from mollie.api.objects.list import List
+
 
 def test_get_issuers(client, response):
     """Get all the iDeal issuers via the include querystring parameter."""
     response.get('https://api.mollie.com/v2/methods/ideal?include=issuers', 'method_get_ideal_with_includes')
 
     issuers = client.methods.get('ideal', include='issuers').issuers
-    assert issuers.__class__.__name__ == 'List'
-    assert len(issuers) == 11
+    assert isinstance(issuers, List)
 
     iterated = 0
     iterated_issuer_ids = []
     for issuer in issuers:
-        assert issuer.__class__.__name__ == 'Issuer'
-        iterated += 1
+        assert isinstance(issuer, Issuer)
         assert issuer.id is not None
+        iterated += 1
         iterated_issuer_ids.append(issuer.id)
     assert iterated == len(issuers), 'Unexpected amount of issuers retrieved'
     assert len(set(iterated_issuer_ids)) == len(issuers), 'Unexpected number of unique issuers'

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -1,16 +1,19 @@
+from mollie.api.objects.list import List
+from mollie.api.objects.method import Method
+
 
 def test_methods_all(client, response):
     """Retrieve a list of available payment methods."""
     response.get('https://api.mollie.com/v2/methods', 'methods_list')
 
     methods = client.methods.all()
-    assert methods.__class__.__name__ == 'List'
+    assert isinstance(methods, List)
     assert methods.count == 11
 
     iterated = 0
     iterated_method_ids = []
     for method in methods:
-        assert method.__class__.__name__ == 'Method'
+        assert isinstance(method, Method)
         iterated += 1
         assert method.id is not None
         iterated_method_ids.append(method.id)
@@ -23,8 +26,8 @@ def test_method_get(client, response):
     response.get('https://api.mollie.com/v2/methods/ideal', 'method_get_ideal')
 
     method = client.methods.get('ideal')
-    assert method.__class__.__name__ == 'Method'
-    assert method.id == 'ideal'
+    assert isinstance(method, Method)
+    assert method.id == Method.IDEAL
     assert method.description == 'iDEAL'
     assert method.image_size1x == 'https://www.mollie.com/images/payscreen/methods/ideal.png'
     assert method.image_size2x == 'https://www.mollie.com/images/payscreen/methods/ideal%402x.png'

--- a/tests/test_payment_chargebacks.py
+++ b/tests/test_payment_chargebacks.py
@@ -6,7 +6,7 @@ CHARGEBACK_ID = 'chb_n9z0tp'
 
 
 def test_get_payment_chargeback_by_payment_id(client, response):
-    """Get chargebacks relevant to payment by payment id"""
+    """Get chargebacks relevant to payment by payment id."""
     response.get('https://api.mollie.com/v2/payments/%s/chargebacks' % PAYMENT_ID, 'chargebacks_list')
 
     chargebacks = client.payment_chargebacks.with_parent_id(PAYMENT_ID).all()
@@ -26,7 +26,7 @@ def test_get_payment_chargeback_by_payment_id(client, response):
 
 
 def test_get_single_payment_chargeback(client, response):
-    """Get a single chargeback relevant to payment by payment id"""
+    """Get a single chargeback relevant to payment by payment id."""
     response.get('https://api.mollie.com/v2/payments/%s/chargebacks/%s' % (PAYMENT_ID, CHARGEBACK_ID),
                  'chargeback_single')
 
@@ -43,7 +43,7 @@ def test_get_single_payment_chargeback(client, response):
 
 
 def test_get_all_payment_chargebacks_by_payment_object(client, response):
-    """Get all chargebacks relevant to payment object"""
+    """Get all chargebacks relevant to payment object."""
     response.get('https://api.mollie.com/v2/payments/%s/chargebacks' % PAYMENT_ID, 'chargebacks_list')
     response.get('https://api.mollie.com/v2/payments/%s' % PAYMENT_ID, 'payment_single')
 
@@ -65,7 +65,7 @@ def test_get_all_payment_chargebacks_by_payment_object(client, response):
 
 
 def test_get_single_payment_chargeback_by_payment_object(client, response):
-    """Get a single chargeback relevant to payment object"""
+    """Get a single chargeback relevant to payment object."""
     response.get('https://api.mollie.com/v2/payments/%s/chargebacks/%s' % (PAYMENT_ID, CHARGEBACK_ID),
                  'chargeback_single')
     response.get('https://api.mollie.com/v2/payments/%s' % PAYMENT_ID, 'payment_single')

--- a/tests/test_payment_chargebacks.py
+++ b/tests/test_payment_chargebacks.py
@@ -10,8 +10,8 @@ def test_get_payment_chargeback_by_payment_id(client, response):
     response.get('https://api.mollie.com/v2/payments/%s/chargebacks' % PAYMENT_ID, 'chargebacks_list')
 
     chargebacks = client.payment_chargebacks.with_parent_id(PAYMENT_ID).all()
-    assert chargebacks.count == 1
     assert isinstance(chargebacks, List)
+    assert chargebacks.count == 1
 
     iterated = 0
     iterated_chargeback_ids = []
@@ -21,8 +21,8 @@ def test_get_payment_chargeback_by_payment_id(client, response):
         iterated += 1
         iterated_chargeback_ids.append(chargeback.id)
     assert iterated == chargebacks.count, 'Unexpected amount of chargebacks retrieved'
-    assert len(
-        set(iterated_chargeback_ids)) == chargebacks.count, 'Unexpected amount of unique chargeback ids retrieved'
+    assert len(set(iterated_chargeback_ids)) == chargebacks.count, \
+        'Unexpected amount of unique chargeback ids retrieved'
 
 
 def test_get_single_payment_chargeback(client, response):
@@ -33,10 +33,8 @@ def test_get_single_payment_chargeback(client, response):
     chargeback = client.payment_chargebacks.with_parent_id(PAYMENT_ID).get(CHARGEBACK_ID)
     assert isinstance(chargeback, Chargeback)
     assert chargeback.id == CHARGEBACK_ID
-    assert chargeback.amount['currency'] == 'USD'
-    assert chargeback.amount['value'] == '43.38'
-    assert chargeback.settlement_amount['currency'] == 'EUR'
-    assert chargeback.settlement_amount['value'] == '-35.07'
+    assert chargeback.amount == {'currency': 'USD', 'value': '43.38'}
+    assert chargeback.settlement_amount == {'currency': 'EUR', 'value': '-35.07'}
     assert chargeback.created_at == '2018-03-14T17:00:52.0Z'
     assert chargeback.reversed_at == '2018-03-14T17:00:55.0Z'
     assert chargeback.payment_id == PAYMENT_ID
@@ -49,8 +47,8 @@ def test_get_all_payment_chargebacks_by_payment_object(client, response):
 
     payment = client.payments.get(PAYMENT_ID)
     chargebacks = client.payment_chargebacks.on(payment).all()
-    assert chargebacks.count == 1
     assert isinstance(chargebacks, List)
+    assert chargebacks.count == 1
 
     iterated = 0
     iterated_chargeback_ids = []

--- a/tests/test_payment_refunds.py
+++ b/tests/test_payment_refunds.py
@@ -10,14 +10,13 @@ def test_get_refund(client, response):
     response.get('https://api.mollie.com/v2/payments/%s/refunds/%s' % (PAYMENT_ID, REFUND_ID), 'refund_single')
 
     refund = client.payment_refunds.with_parent_id(PAYMENT_ID).get(REFUND_ID)
+    assert isinstance(refund, Refund)
     assert refund.resource == 'refund'
     assert refund.id == REFUND_ID
-    assert refund.amount['currency'] == 'EUR'
-    assert refund.amount['value'] == '5.95'
-    assert refund.settlement_amount['currency'] == 'EUR'
-    assert refund.settlement_amount['value'] == '10.00'
+    assert refund.amount == {'currency': 'EUR', 'value': '5.95'}
+    assert refund.settlement_amount == {'currency': 'EUR', 'value': '10.00'}
     assert refund.description == 'Order'
-    assert refund.status == 'pending'
+    assert refund.status == Refund.STATUS_PENDING
     assert refund.created_at == '2018-03-14T17:09:02.0Z'
     assert refund.payment_id == PAYMENT_ID
 
@@ -30,8 +29,8 @@ def test_create_refund(client, response):
         'amount': {'value': '5.95', 'currency': 'EUR'}
     }
     refund = client.payment_refunds.with_parent_id(PAYMENT_ID).create(data)
-    assert refund.id == REFUND_ID
     assert isinstance(refund, Refund)
+    assert refund.id == REFUND_ID
 
 
 def test_get_single_refund_on_payment_object(client, response):
@@ -41,8 +40,8 @@ def test_get_single_refund_on_payment_object(client, response):
 
     payment = client.payments.get(PAYMENT_ID)
     refund = client.payment_refunds.on(payment).get(REFUND_ID)
-    assert refund.id == REFUND_ID
     assert isinstance(refund, Refund)
+    assert refund.id == REFUND_ID
 
 
 def test_get_all_refunds_on_payment_object(client, response):
@@ -52,8 +51,8 @@ def test_get_all_refunds_on_payment_object(client, response):
 
     payment = client.payments.get(PAYMENT_ID)
     refunds = client.payment_refunds.on(payment).all()
-    assert refunds.count == 1
     assert isinstance(refunds, List)
+    assert refunds.count == 1
 
     iterated = 0
     iterated_refund_ids = []

--- a/tests/test_payment_refunds.py
+++ b/tests/test_payment_refunds.py
@@ -6,7 +6,7 @@ REFUND_ID = 're_4qqhO89gsT'
 
 
 def test_get_refund(client, response):
-    """Retrieve a specific refund of a payment"""
+    """Retrieve a specific refund of a payment."""
     response.get('https://api.mollie.com/v2/payments/%s/refunds/%s' % (PAYMENT_ID, REFUND_ID), 'refund_single')
 
     refund = client.payment_refunds.with_parent_id(PAYMENT_ID).get(REFUND_ID)
@@ -23,7 +23,7 @@ def test_get_refund(client, response):
 
 
 def test_create_refund(client, response):
-    """Create a payment refund of a payment"""
+    """Create a payment refund of a payment."""
     response.post('https://api.mollie.com/v2/payments/%s/refunds' % PAYMENT_ID, 'refund_single')
 
     data = {
@@ -35,7 +35,7 @@ def test_create_refund(client, response):
 
 
 def test_get_single_refund_on_payment_object(client, response):
-    """Retrieve a payment refund of a payment"""
+    """Retrieve a payment refund of a payment."""
     response.get('https://api.mollie.com/v2/payments/%s' % PAYMENT_ID, 'payment_single')
     response.get('https://api.mollie.com/v2/payments/%s/refunds/%s' % (PAYMENT_ID, REFUND_ID), 'refund_single')
 
@@ -46,7 +46,7 @@ def test_get_single_refund_on_payment_object(client, response):
 
 
 def test_get_all_refunds_on_payment_object(client, response):
-    """Retrieve all payment refunds of a payment"""
+    """Retrieve all payment refunds of a payment."""
     response.get('https://api.mollie.com/v2/payments/%s' % PAYMENT_ID, 'payment_single')
     response.get('https://api.mollie.com/v2/payments/%s/refunds' % PAYMENT_ID, 'refunds_list')
 
@@ -67,7 +67,7 @@ def test_get_all_refunds_on_payment_object(client, response):
 
 
 def test_cancel_refund(client, response):
-    """Cancel a refund of a payment"""
+    """Cancel a refund of a payment."""
     response.delete('https://api.mollie.com/v2/payments/%s/refunds/%s' % (PAYMENT_ID, REFUND_ID), 'empty')
 
     canceled_refund = client.payment_refunds.with_parent_id(PAYMENT_ID).delete(REFUND_ID)

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -11,7 +11,7 @@ CUSTOMER_ID = 'cst_8wmqcHMN4U'
 
 
 def test_get_all_payments(client, response):
-    """Retrieve all existing payments"""
+    """Retrieve all existing payments."""
     response.get('https://api.mollie.com/v2/payments', 'payments_list')
 
     payments = client.payments.all()
@@ -29,7 +29,7 @@ def test_get_all_payments(client, response):
 
 
 def test_create_payment(client, response):
-    """Create a new payment"""
+    """Create a new payment."""
     response.post('https://api.mollie.com/v2/payments', 'payment_single')
 
     payment = client.payments.create(
@@ -44,7 +44,7 @@ def test_create_payment(client, response):
 
 
 def test_cancel_payment(client, response):
-    """Cancel existing payment"""
+    """Cancel existing payment."""
     response.delete('https://api.mollie.com/v2/payments/%s' % PAYMENT_ID, 'payment_canceled', 200)
 
     canceled_payment = client.payments.delete(PAYMENT_ID)
@@ -54,7 +54,7 @@ def test_cancel_payment(client, response):
 
 
 def test_get_single_payment(client, response):
-    """Retrieve a single payment by payment id,"""
+    """Retrieve a single payment by payment id."""
     response.get('https://api.mollie.com/v2/payments/%s' % PAYMENT_ID, 'payment_single')
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_single')
 
@@ -92,8 +92,8 @@ def test_get_single_payment(client, response):
     assert payment.has_sequence_type_recurring() is False
 
 
-def test_get_all_related_refunds_of_payment(client, response):
-    """Retrieve a list of all refunds related to a payment"""
+def test_payment_get_related_refunds(client, response):
+    """Retrieve a list of all refunds related to a payment."""
     response.get('https://api.mollie.com/v2/payments/%s' % PAYMENT_ID, 'payment_single')
     response.get('https://api.mollie.com/v2/payments/%s/refunds/%s' % (PAYMENT_ID, REFUND_ID), 'refunds_list')
 
@@ -113,8 +113,8 @@ def test_get_all_related_refunds_of_payment(client, response):
     assert len(set(iterated_refund_ids)) == refunds.count, 'Expected unique refund ids retrieved'
 
 
-def test_get_related_chargebacks(client, response):
-    """Get chargebacks related to payment id"""
+def test_payment_get_related_chargebacks(client, response):
+    """Get chargebacks related to payment id."""
     response.get('https://api.mollie.com/v2/payments/%s' % PAYMENT_ID, 'payment_single')
     response.get('https://api.mollie.com/v2/payments/%s/chargebacks' % PAYMENT_ID, 'chargebacks_list')
 

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -18,12 +18,13 @@ def test_get_all_payments(client, response):
     payments = client.payments.all()
     assert isinstance(payments, List)
     assert payments.count == 3
+
     iterated = 0
     iterated_payment_ids = []
     for payment in payments:
-        iterated += 1
         assert isinstance(payment, Payment)
         assert payment.id is not None
+        iterated += 1
         iterated_payment_ids.append(payment.id)
     assert iterated == payments.count, 'Unexpected amount of payments retrieved'
     assert len(set(iterated_payment_ids)) == payments.count, 'Unexpected unique payment ids retrieved'
@@ -49,6 +50,7 @@ def test_cancel_payment(client, response):
     response.delete('https://api.mollie.com/v2/payments/%s' % PAYMENT_ID, 'payment_canceled', 200)
 
     canceled_payment = client.payments.delete(PAYMENT_ID)
+    assert isinstance(canceled_payment, Payment)
     assert canceled_payment.is_canceled() is True
     assert canceled_payment.canceled_at == '2018-03-20T09:28:37+00:00'
     assert canceled_payment.id == PAYMENT_ID
@@ -62,6 +64,7 @@ def test_get_single_payment(client, response):
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_single')
 
     payment = client.payments.get(PAYMENT_ID)
+    assert isinstance(payment, Payment)
     assert payment.amount == {'value': '10.00', 'currency': 'EUR'}
     assert payment.description == 'Order #12345'
     assert payment.redirect_url == 'https://webshop.example.org/order/12345/'
@@ -109,8 +112,8 @@ def test_payment_get_related_refunds(client, response):
 
     payment = client.payments.get(PAYMENT_ID)
     refunds = payment.refunds
-    assert refunds.count == 1
     assert isinstance(refunds, List)
+    assert refunds.count == 1
 
     iterated = 0
     iterated_refund_ids = []

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -70,7 +70,6 @@ def test_get_single_payment(client, response):
     assert payment.metadata == {'order_id': '12345'}
     assert payment.sequence_type == 'oneoff'
     assert payment.profile_id == 'pfl_QkEhN94Ba'
-    assert payment.can_be_refunded is False
     assert payment.checkout_url == 'https://www.mollie.com/payscreen/select-method/7UhSN1zuXS'
     assert payment.resource == 'payment'
     assert payment.id == PAYMENT_ID
@@ -88,6 +87,7 @@ def test_get_single_payment(client, response):
     assert payment.is_paid() is False
     assert payment.is_failed() is False
     assert payment.has_refunds() is True
+    assert payment.can_be_refunded() is False
     assert payment.has_sequence_type_first() is False
     assert payment.has_sequence_type_recurring() is False
 

--- a/tests/test_refunds.py
+++ b/tests/test_refunds.py
@@ -3,7 +3,7 @@ from mollie.api.objects.refund import Refund
 
 
 def test_list_all_refunds(client, response):
-    """Retrieve a list of all refunds"""
+    """Retrieve a list of all refunds."""
     response.get('https://api.mollie.com/v2/refunds', 'refunds_list')
     refunds = client.refunds.all()
     assert refunds.count == 1


### PR DESCRIPTION
As discussed in: https://github.com/mollie/mollie-api-python/pull/45#discussion_r208892711

- Added `Base._get_link()` method
- Refactored all code to use that in stead of try/except everywhere.
- Fixed and extended a few related tests.
- Some minor docstring fixes.