### PR TITLE
Rename all to list

### DIFF
--- a/examples/10-customer-payment-history.py
+++ b/examples/10-customer-payment-history.py
@@ -30,16 +30,17 @@ def main():
         # If no customer ID was provided in the URL, we grab the first customer
         customer = None
         if customer_id is None:
+
+            body += '<p>No customer ID specified. Attempting to retrieve the first page of customers '
+            body += 'and grabbing the first.</p>'
+
             customers = mollie_client.customers.list()
 
             if not len(customers):
                 body += '<p>You have no customers. You can create one from the examples.</p>'
                 return body
 
-            body += '<p>No customer ID specified. Attempting to retrieve all customers and grabbing the first.</p>'
-
             customer = next(customers)
-            customer_id = customer.id
 
         if not customer:
             customer = mollie_client.customers.get(customer_id)

--- a/examples/10-customer-payment-history.py
+++ b/examples/10-customer-payment-history.py
@@ -28,20 +28,21 @@ def main():
         customer_id = flask.request.args.get('customer_id')
 
         # If no customer ID was provided in the URL, we grab the first customer
+        customer = None
         if customer_id is None:
-            customers = mollie_client.customers.all()
+            customers = mollie_client.customers.list()
 
-            body += '<p>No customer ID specified. Attempting to retrieve all customers and grabbing the first.</p>'
-
-            if int(customers.count) == 0:
+            if not len(customers):
                 body += '<p>You have no customers. You can create one from the examples.</p>'
                 return body
 
-            for customer in customers:
-                customer_id = customer.id
-                break
+            body += '<p>No customer ID specified. Attempting to retrieve all customers and grabbing the first.</p>'
 
-        customer = mollie_client.customers.get(customer_id)
+            customer = next(customers)
+            customer_id = customer.id
+
+        if not customer:
+            customer = mollie_client.customers.get(customer_id)
 
         amount_of_payments_to_retrieve = 20
 
@@ -53,7 +54,7 @@ def main():
         params = {
             'limit': amount_of_payments_to_retrieve,
         }
-        payments = mollie_client.customer_payments.with_parent_id(customer_id).all(**params)
+        payments = mollie_client.customer_payments.with_parent_id(customer_id).list(**params)
 
         body += '<p>Showing the last %s payments for customer "%s"</p>' % (payments.count, customer.id)
 

--- a/examples/11-refund-payment.py
+++ b/examples/11-refund-payment.py
@@ -25,20 +25,17 @@ def main():
         body = ''
         payment_id = ''
 
-        payments = mollie_client.payments.all()
+        payments = mollie_client.payments.list()
 
-        body += '<p>Attempting to retrieve the first page of payments and grabbing the first.</p>'
-
-        if int(payments.count) == 0:
+        if not len(payments):
             body += '<p>You have no payments. You can create one from the examples.</p>'
             return body
 
-        for payment in payments:
-            payment_id = payment.id
-            break
+        body += '<p>Attempting to retrieve the first page of payments and grabbing the first.</p>'
 
-        payment = mollie_client.payments.get(payment_id)
-        if payment.can_be_refunded and payment.amount_remaining['currency'] == 'EUR' \
+        payment = next(payments)
+
+        if payment.can_be_refunded() and payment.amount_remaining['currency'] == 'EUR' \
                 and float(payment.amount_remaining['value']) >= 2.0:
             data = {
                 'amount': {'value': '2.00', 'currency': 'EUR'}

--- a/examples/11-refund-payment.py
+++ b/examples/11-refund-payment.py
@@ -25,13 +25,13 @@ def main():
         body = ''
         payment_id = ''
 
+        body += '<p>Attempting to retrieve the first page of payments and grabbing the first.</p>'
+
         payments = mollie_client.payments.list()
 
         if not len(payments):
             body += '<p>You have no payments. You can create one from the examples.</p>'
             return body
-
-        body += '<p>Attempting to retrieve the first page of payments and grabbing the first.</p>'
 
         payment = next(payments)
 

--- a/examples/5-payments-history.py
+++ b/examples/5-payments-history.py
@@ -24,9 +24,15 @@ def main():
         #
         # Get the first page of payments for this API key ordered by newest.
         #
-        payments = mollie_client.payments.all()
+        payments = mollie_client.payments.list()
 
-        body = 'Showing the first page of payments for this API key<br>'
+        body = ''
+
+        if not len(payments):
+            body += '<p>You have no payments. You can create one from the examples.</p>'
+            return body
+
+        body += '<p>Showing the first page of payments for this API key</p>'
 
         for payment in payments:
             body += "%s %s, status: '%s'<br>" % (payment.amount['value'], payment.amount['currency'], payment.status)

--- a/examples/6-list-activated-methods.py
+++ b/examples/6-list-activated-methods.py
@@ -30,8 +30,8 @@ def main():
                 'value': '100.00',
             }
         }
-        methods = mollie_client.methods.all(**params)
-        body = 'Your API key has %u activated payment methods:<br>' % methods.count
+        methods = mollie_client.methods.list(**params)
+        body = 'Your API key has %u activated payment methods:<br>' % len(methods)
 
         for method in methods:
             body += '<div style="line-height:40px; vertical-align:top">'

--- a/examples/8-list-customers.py
+++ b/examples/8-list-customers.py
@@ -31,12 +31,15 @@ def main():
         #
         # See: https://www.mollie.com/nl/docs/reference/customers/list
         #
-        customers = mollie_client.customers.all(**params)
+        customers = mollie_client.customers.list(**params)
 
-        body = '<p>Showing the last %s customers for your API key.</p>' % customers.count
+        body = ''
 
-        if int(customers.count) == 0:
+        if not len(customers):
+            body += '<p>You have no customers. You can create one from the examples.</p>'
             return body
+
+        body += '<p>Showing the last %s customers for your API key.</p>' % len(customers)
 
         body += """
             <table>

--- a/examples/9-create-customer-payment.py
+++ b/examples/9-create-customer-payment.py
@@ -30,19 +30,22 @@ def main():
         customer_id = flask.request.args.get('customer_id')
 
         # If no customer ID was provided in the URL, we grab the first customer
+        customer = None
         if customer_id is None:
-            customers = mollie_client.customers.all()
+            customers = mollie_client.customers.list()
 
             body += '<p>No customer ID specified. Attempting to retrieve the first page of '
             body += 'customers and grabbing the first.</p>'
 
-            if int(customers.count) == 0:
+            if not len(customers):
                 body += '<p>You have no customers. You can create one from the examples.</p>'
                 return body
 
-            customer_id = next(customers).id
+            customer = next(customers)
+            customer_id = customer.id
 
-        customer = mollie_client.customers.get(customer_id)
+        if not customer:
+            customer = mollie_client.customers.get(customer_id)
 
         #
         # Generate a unique order number for this example. It is important to include this unique attribute

--- a/examples/9-create-customer-payment.py
+++ b/examples/9-create-customer-payment.py
@@ -42,7 +42,6 @@ def main():
                 return body
 
             customer = next(customers)
-            customer_id = customer.id
 
         if not customer:
             customer = mollie_client.customers.get(customer_id)
@@ -56,7 +55,7 @@ def main():
         #
         # See: https://www.mollie.com/nl/docs/reference/customers/create-payment
         #
-        payment = mollie_client.customer_payments.with_parent_id(customer_id).create({
+        payment = mollie_client.customer_payments.with_parent_id(customer.id).create({
             'amount': {'currency': 'EUR', 'value': '100.00'},
             'description': 'My first API payment',
             'webhookUrl': flask.request.url_root + '2-webhook_verification',

--- a/mollie/api/objects/list.py
+++ b/mollie/api/objects/list.py
@@ -30,6 +30,7 @@ class List(Base):
             item = self['_embedded'][self.get_object_name()][self.current]
             return self.object_type(item)
         except IndexError:
+            self.current = None
             raise StopIteration
 
     next = __next__  # support python2 iterator interface

--- a/mollie/api/resources/base.py
+++ b/mollie/api/resources/base.py
@@ -67,7 +67,7 @@ class Base(object):
     def delete(self, resource_id):
         return self.rest_delete(resource_id)
 
-    def all(self, **params):
+    def list(self, **params):
         return self.rest_list(params)
 
     def perform_api_call(self, http_method, path, data=None, params=None):

--- a/tests/responses/method_get_ideal_with_includes.json
+++ b/tests/responses/method_get_ideal_with_includes.json
@@ -21,7 +21,7 @@
       "id": "ideal_ABNANL2A",
       "image": {
         "size1x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/ABNANL2A.png",
-        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/ABNANL2A.png",
+        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/ABNANL2A%402x.png",
         "svg": "https://www.mollie.com/external/icons/ideal-issuers/ABNANL2A.svg"
       },
       "name": "ABN AMRO",
@@ -31,7 +31,7 @@
       "id": "ideal_ASNBNL21",
       "image": {
         "size1x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/ASNBNL21.png",
-        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/ASNBNL21.png",
+        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/ASNBNL21%402x.png",
         "svg": "https://www.mollie.com/external/icons/ideal-issuers/ASNBNL21.svg"
       },
       "name": "ASN Bank",
@@ -41,7 +41,7 @@
       "id": "ideal_BUNQNL2A",
       "image": {
         "size1x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/BUNQNL2A.png",
-        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/BUNQNL2A.png",
+        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/BUNQNL2A%402x.png",
         "svg": "https://www.mollie.com/external/icons/ideal-issuers/BUNQNL2A.svg"
       },
       "name": "bunq",
@@ -51,7 +51,7 @@
       "id": "ideal_INGBNL2A",
       "image": {
         "size1x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/INGBNL2A.png",
-        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/INGBNL2A.png",
+        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/INGBNL2A%402x.png",
         "svg": "https://www.mollie.com/external/icons/ideal-issuers/INGBNL2A.svg"
       },
       "name": "ING",
@@ -61,7 +61,7 @@
       "id": "ideal_KNABNL2H",
       "image": {
         "size1x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/KNABNL2H.png",
-        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/KNABNL2H.png",
+        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/KNABNL2H%402x.png",
         "svg": "https://www.mollie.com/external/icons/ideal-issuers/KNABNL2H.svg"
       },
       "name": "Knab",
@@ -71,7 +71,7 @@
       "id": "ideal_MOYONL21",
       "image": {
         "size1x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/MOYONL21.png",
-        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/MOYONL21.png",
+        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/MOYONL21%402x.png",
         "svg": "https://www.mollie.com/external/icons/ideal-issuers/MOYONL21.svg"
       },
       "name": "Moneyou",
@@ -81,7 +81,7 @@
       "id": "ideal_RABONL2U",
       "image": {
         "size1x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/RABONL2U.png",
-        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/RABONL2U.png",
+        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/RABONL2U%402x.png",
         "svg": "https://www.mollie.com/external/icons/ideal-issuers/RABONL2U.svg"
       },
       "name": "Rabobank",
@@ -91,7 +91,7 @@
       "id": "ideal_RBRBNL21",
       "image": {
         "size1x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/RBRBNL21.png",
-        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/RBRBNL21.png",
+        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/RBRBNL21%402x.png",
         "svg": "https://www.mollie.com/external/icons/ideal-issuers/RBRBNL21.svg"
       },
       "name": "RegioBank",
@@ -101,7 +101,7 @@
       "id": "ideal_SNSBNL2A",
       "image": {
         "size1x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/SNSBNL2A.png",
-        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/SNSBNL2A.png",
+        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/SNSBNL2A%402x.png",
         "svg": "https://www.mollie.com/external/icons/ideal-issuers/SNSBNL2A.svg"
       },
       "name": "SNS Bank",
@@ -111,7 +111,7 @@
       "id": "ideal_TRIONL2U",
       "image": {
         "size1x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/TRIONL2U.png",
-        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/TRIONL2U.png",
+        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/TRIONL2U%402x.png",
         "svg": "https://www.mollie.com/external/icons/ideal-issuers/TRIONL2U.svg"
       },
       "name": "Triodos Bank",
@@ -121,7 +121,7 @@
       "id": "ideal_FVLBNL22",
       "image": {
         "size1x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/FVLBNL22.png",
-        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/FVLBNL22.png",
+        "size2x": "https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/FVLBNL22%402x.png",
         "svg": "https://www.mollie.com/external/icons/ideal-issuers/FVLBNL22.svg"
       },
       "name": "van Lanschot",

--- a/tests/test_chargebacks.py
+++ b/tests/test_chargebacks.py
@@ -4,7 +4,7 @@ from .utils import assert_list_object
 
 
 def test_list_chargebacks(client, response):
-    """Get all chargebacks."""
+    """Get a list of chargebacks."""
     response.get('https://api.mollie.com/v2/chargebacks', 'chargebacks_list')
 
     chargebacks = client.chargebacks.list()

--- a/tests/test_chargebacks.py
+++ b/tests/test_chargebacks.py
@@ -1,5 +1,6 @@
 from mollie.api.objects.chargeback import Chargeback
-from mollie.api.objects.list import List
+
+from .utils import assert_list_object
 
 
 def test_list_chargebacks(client, response):
@@ -7,16 +8,4 @@ def test_list_chargebacks(client, response):
     response.get('https://api.mollie.com/v2/chargebacks', 'chargebacks_list')
 
     chargebacks = client.chargebacks.list()
-    assert isinstance(chargebacks, List)
-    assert chargebacks.count == 1
-
-    iterated = 0
-    iterated_chargeback_ids = []
-    for chargeback in chargebacks:
-        assert isinstance(chargeback, Chargeback)
-        assert chargeback.id is not None
-        iterated += 1
-        iterated_chargeback_ids.append(chargeback.id)
-    assert iterated == chargebacks.count, 'Unexpected amount of chargebacks retrieved'
-    assert len(
-        set(iterated_chargeback_ids)) == chargebacks.count, 'Unexpected amount of unique chargeback ids retrieved'
+    assert_list_object(chargebacks, Chargeback)

--- a/tests/test_chargebacks.py
+++ b/tests/test_chargebacks.py
@@ -2,11 +2,11 @@ from mollie.api.objects.chargeback import Chargeback
 from mollie.api.objects.list import List
 
 
-def test_get_all_chargebacks(client, response):
+def test_list_chargebacks(client, response):
     """Get all chargebacks."""
     response.get('https://api.mollie.com/v2/chargebacks', 'chargebacks_list')
 
-    chargebacks = client.chargebacks.all()
+    chargebacks = client.chargebacks.list()
     assert isinstance(chargebacks, List)
     assert chargebacks.count == 1
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -38,7 +38,7 @@ def test_client_querystring(client, response):
     )
 
     params = {'amount': {'currency': 'USD', 'value': '100.00'}}
-    methods = client.methods.all(**params)
+    methods = client.methods.list(**params)
     assert methods.count == 11
 
 
@@ -46,7 +46,7 @@ def test_client_no_api_key():
     """A Request without an API key should raise an error."""
     client = Client()
     with pytest.raises(RequestSetupError) as excinfo:
-        client.customers.all()
+        client.customers.list()
     assert excinfo.match('You have not set an API key.')
 
 
@@ -67,7 +67,7 @@ def test_client_no_cert_bundle(monkeypatch):
     client = Client()
     client.set_api_key('test_test')
     with pytest.raises(RequestSetupError) as excinfo:
-        client.customers.all()
+        client.customers.list()
     assert excinfo.match('Unable to load cacert.pem')
 
 
@@ -81,7 +81,7 @@ def test_client_generic_request_error(response):
     client.set_api_key('test_test')
     client.set_api_endpoint('https://api.mollie.invalid/')
     with pytest.raises(RequestError) as excinfo:
-        client.customers.all()
+        client.customers.list()
     assert excinfo.match('Unable to communicate with Mollie: Connection refused')
 
 
@@ -140,7 +140,7 @@ def test_client_invalid_json_response(client, response):
     """An invalid json response should raise an error."""
     response.get('https://api.mollie.com/v2/customers', 'invalid_json')
     with pytest.raises(ResponseHandlingError) as excinfo:
-        client.customers.all()
+        client.customers.list()
     assert excinfo.match(r'Unable to decode Mollie API response \(status code: 200\)')
 
 
@@ -172,7 +172,7 @@ def test_client_response_404_but_no_payload(response):
     client.set_api_key('test_test')
 
     with pytest.raises(ResponseHandlingError) as excinfo:
-        client.customers.all()
+        client.customers.list()
     assert excinfo.match('Invalid API version')
 
 

--- a/tests/test_customer_mandates.py
+++ b/tests/test_customer_mandates.py
@@ -6,10 +6,10 @@ CUSTOMER_ID = 'cst_8wmqcHMN4U'
 MANDATE_ID = 'mdt_h3gAaD5zP'
 
 
-def test_customer_mandates_all(client, response):
+def test_list_customer_mandates(client, response):
     """Retrieve a list of mandates."""
     response.get('https://api.mollie.com/v2/customers/%s/mandates' % CUSTOMER_ID, 'customer_mandates_list')
-    mandates = client.customer_mandates.with_parent_id(CUSTOMER_ID).all()
+    mandates = client.customer_mandates.with_parent_id(CUSTOMER_ID).list()
     assert isinstance(mandates, List)
     assert mandates.count == 1
 
@@ -62,7 +62,8 @@ def test_get_customer_mandate_by_customer(client, response):
     )
     customer = client.customers.get(CUSTOMER_ID)
 
-    mandates = client.customer_mandates.on(customer).all()
+    mandates = client.customer_mandates.on(customer).list()
+    assert isinstance(mandates, List)
     assert MANDATE_ID in [x.id for x in mandates]
 
     mandate = client.customer_mandates.on(customer).get(MANDATE_ID)

--- a/tests/test_customer_mandates.py
+++ b/tests/test_customer_mandates.py
@@ -1,6 +1,7 @@
 from mollie.api.objects.customer import Customer
-from mollie.api.objects.list import List
 from mollie.api.objects.mandate import Mandate
+
+from .utils import assert_list_object
 
 CUSTOMER_ID = 'cst_8wmqcHMN4U'
 MANDATE_ID = 'mdt_h3gAaD5zP'
@@ -10,18 +11,7 @@ def test_list_customer_mandates(client, response):
     """Retrieve a list of mandates."""
     response.get('https://api.mollie.com/v2/customers/%s/mandates' % CUSTOMER_ID, 'customer_mandates_list')
     mandates = client.customer_mandates.with_parent_id(CUSTOMER_ID).list()
-    assert isinstance(mandates, List)
-    assert mandates.count == 1
-
-    iterated = 0
-    iterated_mandate_ids = []
-    for mandate in mandates:
-        assert isinstance(mandate, Mandate)
-        iterated += 1
-        assert mandate.id is not None
-        iterated_mandate_ids.append(mandate.id)
-    assert iterated == mandates.count, 'Unexpected amount of mandates retrieved'
-    assert len(set(iterated_mandate_ids)) == mandates.count, 'Unexpected unique mandate ids retrieved'
+    assert_list_object(mandates, Mandate)
 
 
 def test_get_customer_mandate_by_id(client, response):
@@ -53,7 +43,7 @@ def test_get_customer_mandate_by_id(client, response):
 
 
 def test_get_customer_mandate_by_customer(client, response):
-    """Retrieve a customer by customer object, ensure request is correct."""
+    """Retrieve a customer by customer object."""
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_new')
     response.get('https://api.mollie.com/v2/customers/%s/mandates' % CUSTOMER_ID, 'customer_mandates_list')
     response.get(
@@ -63,8 +53,7 @@ def test_get_customer_mandate_by_customer(client, response):
     customer = client.customers.get(CUSTOMER_ID)
 
     mandates = client.customer_mandates.on(customer).list()
-    assert isinstance(mandates, List)
-    assert MANDATE_ID in [x.id for x in mandates]
+    assert_list_object(mandates, Mandate)
 
     mandate = client.customer_mandates.on(customer).get(MANDATE_ID)
     assert isinstance(mandate, Mandate)

--- a/tests/test_customer_payments.py
+++ b/tests/test_customer_payments.py
@@ -4,11 +4,11 @@ from mollie.api.objects.payment import Payment
 CUSTOMER_ID = 'cst_8wmqcHMN4U'
 
 
-def test_get_all_customer_payments(client, response):
+def test_list_customer_payments(client, response):
     """Retrieve a list of payments related to a customer id."""
     response.get('https://api.mollie.com/v2/customers/%s/payments' % CUSTOMER_ID, 'customer_payments_multiple')
 
-    payments = client.customer_payments.with_parent_id(CUSTOMER_ID).all()
+    payments = client.customer_payments.with_parent_id(CUSTOMER_ID).list()
     assert isinstance(payments, List)
     assert payments.count == 1
     iterated = 0
@@ -27,7 +27,7 @@ def test_list_customer_payments_by_object(client, response):
     response.get('https://api.mollie.com/v2/customers/%s/payments' % CUSTOMER_ID, 'customer_payments_multiple')
 
     customer = client.customers.get(CUSTOMER_ID)
-    payments = client.customer_payments.on(customer).all()
+    payments = client.customer_payments.on(customer).list()
     assert isinstance(payments, List)
     for payment in payments:
         assert isinstance(payment, Payment)

--- a/tests/test_customer_payments.py
+++ b/tests/test_customer_payments.py
@@ -1,5 +1,6 @@
-from mollie.api.objects.list import List
 from mollie.api.objects.payment import Payment
+
+from .utils import assert_list_object
 
 CUSTOMER_ID = 'cst_8wmqcHMN4U'
 
@@ -9,17 +10,7 @@ def test_list_customer_payments(client, response):
     response.get('https://api.mollie.com/v2/customers/%s/payments' % CUSTOMER_ID, 'customer_payments_multiple')
 
     payments = client.customer_payments.with_parent_id(CUSTOMER_ID).list()
-    assert isinstance(payments, List)
-    assert payments.count == 1
-    iterated = 0
-    iterated_payment_ids = []
-    for payment in payments:
-        assert isinstance(payment, Payment)
-        assert payment.id is not None
-        iterated += 1
-        iterated_payment_ids.append(payment.id)
-    assert iterated == payments.count, 'Unexpected amount of payments retrieved'
-    assert len(set(iterated_payment_ids)) == payments.count, 'Unexpected unique payment ids retrieved'
+    assert_list_object(payments, Payment)
 
 
 def test_list_customer_payments_by_object(client, response):
@@ -28,9 +19,7 @@ def test_list_customer_payments_by_object(client, response):
 
     customer = client.customers.get(CUSTOMER_ID)
     payments = client.customer_payments.on(customer).list()
-    assert isinstance(payments, List)
-    for payment in payments:
-        assert isinstance(payment, Payment)
+    assert_list_object(payments, Payment)
 
 
 def test_create_customer_payment(client, response):

--- a/tests/test_customer_subscriptions.py
+++ b/tests/test_customer_subscriptions.py
@@ -48,7 +48,7 @@ def test_get_customer_subscription_by_id(client, response):
 
 
 def test_list_customer_subscriptions_by_customer_object(client, response):
-    """Retrieve all subscriptions related to customer."""
+    """Retrieve a list of subscriptions related to customer."""
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_single')
     response.get('https://api.mollie.com/v2/customers/%s/subscriptions' % CUSTOMER_ID,
                  'subscriptions_list')

--- a/tests/test_customer_subscriptions.py
+++ b/tests/test_customer_subscriptions.py
@@ -10,11 +10,11 @@ CUSTOMER_ID = 'cst_8wmqcHMN4U'
 SUBSCRIPTION_ID = 'sub_rVKGtNd6s3'
 
 
-def test_customer_subscriptions_all(client, response):
+def test_list_customer_subscriptions(client, response):
     """Retrieve a list of subscriptions."""
     response.get('https://api.mollie.com/v2/customers/%s/subscriptions' % CUSTOMER_ID, 'subscriptions_list')
 
-    subscriptions = client.customer_subscriptions.with_parent_id(CUSTOMER_ID).all()
+    subscriptions = client.customer_subscriptions.with_parent_id(CUSTOMER_ID).list()
     assert isinstance(subscriptions, List)
     assert subscriptions.count == 3
     iterated = 0
@@ -57,14 +57,14 @@ def test_get_customer_subscription_by_id(client, response):
     assert subscription.is_canceled() is False
 
 
-def test_get_all_customer_subscriptions_by_customer_object(client, response):
+def test_list_customer_subscriptions_by_customer_object(client, response):
     """Retrieve all subscriptions related to customer."""
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_single')
     response.get('https://api.mollie.com/v2/customers/%s/subscriptions' % CUSTOMER_ID,
                  'subscriptions_list')
 
     customer = client.customers.get(CUSTOMER_ID)
-    subscriptions = client.customer_subscriptions.on(customer).all()
+    subscriptions = client.customer_subscriptions.on(customer).list()
     assert isinstance(subscriptions, List)
 
     iterated = 0
@@ -74,7 +74,7 @@ def test_get_all_customer_subscriptions_by_customer_object(client, response):
     assert iterated == subscriptions.count, 'Unexpected amount of subscriptions retrieved'
 
 
-def test_get_one_customer_subscription_by_customer_object(client, response):
+def test_get_customer_subscription_by_customer_object(client, response):
     """Retrieve specific subscription related to customer."""
     response.get('https://api.mollie.com/v2/customers/%s/subscriptions/%s' % (CUSTOMER_ID, SUBSCRIPTION_ID),
                  'subscription_single')

--- a/tests/test_customer_subscriptions.py
+++ b/tests/test_customer_subscriptions.py
@@ -2,9 +2,10 @@ import pytest
 
 from mollie.api.error import IdentifierError
 from mollie.api.objects.customer import Customer
-from mollie.api.objects.list import List
 from mollie.api.objects.method import Method
 from mollie.api.objects.subscription import Subscription
+
+from .utils import assert_list_object
 
 CUSTOMER_ID = 'cst_8wmqcHMN4U'
 SUBSCRIPTION_ID = 'sub_rVKGtNd6s3'
@@ -15,18 +16,7 @@ def test_list_customer_subscriptions(client, response):
     response.get('https://api.mollie.com/v2/customers/%s/subscriptions' % CUSTOMER_ID, 'subscriptions_list')
 
     subscriptions = client.customer_subscriptions.with_parent_id(CUSTOMER_ID).list()
-    assert isinstance(subscriptions, List)
-    assert subscriptions.count == 3
-    iterated = 0
-    iterated_subscription_ids = []
-    for subscription in subscriptions:
-        assert isinstance(subscription, Subscription)
-        assert subscription.id is not None
-        iterated += 1
-        iterated_subscription_ids.append(subscription.id)
-    assert iterated == subscriptions.count, 'Unexpected amount of subscriptions retrieved'
-    assert len(set(iterated_subscription_ids)) == subscriptions.count, \
-        'Unexpected amount of unique subscription ids retrieved'
+    assert_list_object(subscriptions, Subscription)
 
 
 def test_get_customer_subscription_by_id(client, response):
@@ -65,13 +55,7 @@ def test_list_customer_subscriptions_by_customer_object(client, response):
 
     customer = client.customers.get(CUSTOMER_ID)
     subscriptions = client.customer_subscriptions.on(customer).list()
-    assert isinstance(subscriptions, List)
-
-    iterated = 0
-    for subscription in subscriptions:
-        assert isinstance(subscription, Subscription)
-        iterated += 1
-    assert iterated == subscriptions.count, 'Unexpected amount of subscriptions retrieved'
+    assert_list_object(subscriptions, Subscription)
 
 
 def test_get_customer_subscription_by_customer_object(client, response):

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -43,7 +43,7 @@ def test_delete_customer(client, response):
 
 
 def test_list_customers(client, response):
-    """Retrieve a list of all existing customers."""
+    """Retrieve a list of existing customers."""
     response.get('https://api.mollie.com/v2/customers', 'customers_list')
 
     customers = client.customers.list()

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -4,6 +4,8 @@ from mollie.api.objects.mandate import Mandate
 from mollie.api.objects.payment import Payment
 from mollie.api.objects.subscription import Subscription
 
+from .utils import assert_list_object
+
 CUSTOMER_ID = 'cst_8wmqcHMN4U'
 
 
@@ -46,20 +48,10 @@ def test_list_customers(client, response):
     response.get('https://api.mollie.com/v2/customers', 'customers_list')
 
     customers = client.customers.list()
-    assert isinstance(customers, List)
-    assert customers.count == 3
-    iterated = 0
-    iterated_customer_ids = []
-    for customer in customers:
-        assert isinstance(customer, Customer)
-        assert customer.id is not None
-        iterated += 1
-        iterated_customer_ids.append(customer.id)
-    assert iterated == customers.count, 'Unexpected amount of customers retrieved'
-    assert len(set(iterated_customer_ids)) == customers.count, 'Unexpected amount of unique customer ids retrieved'
+    assert_list_object(customers, Customer)
 
 
-def test_customer_get(client, response):
+def test_get_customer(client, response):
     """Retrieve a single customer."""
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_new')
     response.get('https://api.mollie.com/v2/customers/%s/payments' % CUSTOMER_ID, 'customer_payments_multiple')
@@ -86,12 +78,7 @@ def test_customer_get_related_mandates(client, response):
 
     customer = client.customers.get(CUSTOMER_ID)
     mandates = customer.mandates
-    assert isinstance(mandates, List)
-    iterated = 0
-    for mandate in mandates:
-        assert isinstance(mandate, Mandate)
-        iterated += 1
-    assert iterated == mandates.count
+    assert_list_object(mandates, Mandate)
 
 
 def test_customer_get_related_subscriptions(client, response):
@@ -102,13 +89,7 @@ def test_customer_get_related_subscriptions(client, response):
 
     customer = client.customers.get(CUSTOMER_ID)
     subscriptions = customer.subscriptions
-    assert isinstance(subscriptions, List)
-
-    iterated = 0
-    for subscription in subscriptions:
-        assert isinstance(subscription, Subscription)
-        iterated += 1
-    assert iterated == subscriptions.count, 'Unexpected amount of subscriptions retrieved'
+    assert_list_object(subscriptions, Subscription)
 
 
 def test_customer_get_related_payments(client, response):
@@ -118,15 +99,4 @@ def test_customer_get_related_payments(client, response):
 
     customer = client.customers.get(CUSTOMER_ID)
     payments = customer.payments
-    assert isinstance(payments, List)
-    assert payments.count == 1
-
-    iterated = 0
-    iterated_payment_ids = []
-    for payment in payments:
-        iterated += 1
-        assert isinstance(payment, Payment)
-        assert payment.id is not None
-        iterated_payment_ids.append(payment.id)
-    assert iterated == payments.count, 'Unexpected amount of payments retrieved'
-    assert len(set(iterated_payment_ids)) == payments.count, 'Unexpected unique payment ids retrieved'
+    assert_list_object(payments, Payment)

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -33,7 +33,7 @@ def test_update_customer(client, response):
     assert updated_customer.email == 'updated-customer@example.org'
 
 
-def test_delete_customers(client, response):
+def test_delete_customer(client, response):
     """Delete a customer."""
     response.delete('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'empty')
 
@@ -41,11 +41,11 @@ def test_delete_customers(client, response):
     assert deleted_customer == {}
 
 
-def test_customers_all(client, response):
+def test_list_customers(client, response):
     """Retrieve a list of all existing customers."""
     response.get('https://api.mollie.com/v2/customers', 'customers_list')
 
-    customers = client.customers.all()
+    customers = client.customers.list()
     assert isinstance(customers, List)
     assert customers.count == 3
     iterated = 0

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -1,5 +1,4 @@
 from mollie.api.objects.customer import Customer
-from mollie.api.objects.list import List
 from mollie.api.objects.mandate import Mandate
 from mollie.api.objects.payment import Payment
 from mollie.api.objects.subscription import Subscription

--- a/tests/test_issuers.py
+++ b/tests/test_issuers.py
@@ -1,5 +1,6 @@
 from mollie.api.objects.issuer import Issuer
-from mollie.api.objects.list import List
+
+from .utils import assert_list_object
 
 
 def test_get_issuers(client, response):
@@ -7,17 +8,7 @@ def test_get_issuers(client, response):
     response.get('https://api.mollie.com/v2/methods/ideal?include=issuers', 'method_get_ideal_with_includes')
 
     issuers = client.methods.get('ideal', include='issuers').issuers
-    assert isinstance(issuers, List)
-
-    iterated = 0
-    iterated_issuer_ids = []
-    for issuer in issuers:
-        assert isinstance(issuer, Issuer)
-        assert issuer.id is not None
-        iterated += 1
-        iterated_issuer_ids.append(issuer.id)
-    assert iterated == len(issuers), 'Unexpected amount of issuers retrieved'
-    assert len(set(iterated_issuer_ids)) == len(issuers), 'Unexpected number of unique issuers'
+    assert_list_object(issuers, Issuer)
 
     # check the last issuer
     assert issuer.image_svg == 'https://www.mollie.com/external/icons/ideal-issuers/FVLBNL22.svg'

--- a/tests/test_issuers.py
+++ b/tests/test_issuers.py
@@ -10,10 +10,11 @@ def test_get_issuers(client, response):
     issuers = client.methods.get('ideal', include='issuers').issuers
     assert_list_object(issuers, Issuer)
 
-    # check the last issuer
-    assert issuer.image_svg == 'https://www.mollie.com/external/icons/ideal-issuers/FVLBNL22.svg'
-    assert issuer.image_size1x == 'https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/FVLBNL22.png'
-    assert issuer.image_size2x == 'https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/FVLBNL22.png'
-    assert issuer.name == 'van Lanschot'
+    # check a single retrieved issuer
+    issuer = next(issuers)
+    assert issuer.image_svg == 'https://www.mollie.com/external/icons/ideal-issuers/ABNANL2A.svg'
+    assert issuer.image_size1x == 'https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/ABNANL2A.png'
+    assert issuer.image_size2x == 'https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/ABNANL2A%402x.png'
+    assert issuer.name == 'ABN AMRO'
     assert issuer.resource == 'issuer'
-    assert issuer.id == 'ideal_FVLBNL22'
+    assert issuer.id == 'ideal_ABNANL2A'

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -8,7 +8,7 @@ def test_list_iterator_behaviour(client, response):
     """Verify the behaviour of the List object in iterator circumstances."""
     response.get('https://api.mollie.com/v2/methods', 'methods_list')
 
-    methods = client.methods.all()
+    methods = client.methods.list()
     assert isinstance(methods, List)
 
     # walk the list using next()
@@ -50,7 +50,7 @@ def test_list_multiple_api_calls(client, response):
     response.get('https://api.mollie.com/v2/customers?from=cst_8pknKQJzJa&limit=5', 'customers_list_second')
     response.get('https://api.mollie.com/v2/customers?from=cst_HwBHgJgRAf&limit=5', 'customers_list_first')
 
-    customers = client.customers.all(limit=5)
+    customers = client.customers.list(limit=5)
     assert customers.count == 5
     all_customers_count = customers.count
     while customers.has_next():

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -33,6 +33,44 @@ def test_list_iterator_behaviour(client, response):
     assert iterated == methods.count
 
 
+def test_list_multiple_iterations(client, response):
+    """Verify that we can iterate a list multiple times."""
+    response.get('https://api.mollie.com/v2/methods', 'methods_list')
+
+    methods = client.methods.list()
+    # iterate once using next()
+    items_first_run = 0
+    while True:
+        try:
+            next(methods)
+            items_first_run += 1
+        except StopIteration:
+            break
+    assert items_first_run == methods.count
+
+    # iterate again
+    items_second_run = 0
+    while True:
+        try:
+            next(methods)
+            items_second_run += 1
+        except StopIteration:
+            break
+    assert items_second_run == methods.count
+
+    methods = client.methods.list()
+    # iterate once using for loop
+    items_third_run = 0
+    for item in methods:
+        items_third_run += 1
+    assert items_third_run == methods.count
+    # iterate again
+    items_fourth_run = 0
+    for item in methods:
+        items_fourth_run += 1
+    assert items_fourth_run == methods.count
+
+
 @pytest.mark.xfail(strict=True, reason="Pagination interface is still undecided")
 def test_list_multiple_api_calls(client, response):
     """

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -1,5 +1,6 @@
-from mollie.api.objects.list import List
 from mollie.api.objects.method import Method
+
+from .utils import assert_list_object
 
 
 def test_list_methods(client, response):
@@ -7,18 +8,7 @@ def test_list_methods(client, response):
     response.get('https://api.mollie.com/v2/methods', 'methods_list')
 
     methods = client.methods.list()
-    assert isinstance(methods, List)
-    assert methods.count == 11
-
-    iterated = 0
-    iterated_method_ids = []
-    for method in methods:
-        assert isinstance(method, Method)
-        iterated += 1
-        assert method.id is not None
-        iterated_method_ids.append(method.id)
-    assert iterated == methods.count
-    assert len(set(iterated_method_ids)) == methods.count, 'Unexpected number of unique methods'
+    assert_list_object(methods, Method)
 
 
 def test_method_get(client, response):

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -2,11 +2,11 @@ from mollie.api.objects.list import List
 from mollie.api.objects.method import Method
 
 
-def test_methods_all(client, response):
+def test_list_methods(client, response):
     """Retrieve a list of available payment methods."""
     response.get('https://api.mollie.com/v2/methods', 'methods_list')
 
-    methods = client.methods.all()
+    methods = client.methods.list()
     assert isinstance(methods, List)
     assert methods.count == 11
 

--- a/tests/test_payment_chargebacks.py
+++ b/tests/test_payment_chargebacks.py
@@ -29,8 +29,8 @@ def test_get_single_payment_chargeback(client, response):
     assert chargeback.payment_id == PAYMENT_ID
 
 
-def test_get_all_payment_chargebacks_by_payment_object(client, response):
-    """Get all chargebacks relevant to payment object."""
+def test_list_payment_chargebacks_by_payment_object(client, response):
+    """Get a list of chargebacks relevant to payment object."""
     response.get('https://api.mollie.com/v2/payments/%s/chargebacks' % PAYMENT_ID, 'chargebacks_list')
     response.get('https://api.mollie.com/v2/payments/%s' % PAYMENT_ID, 'payment_single')
 

--- a/tests/test_payment_chargebacks.py
+++ b/tests/test_payment_chargebacks.py
@@ -1,5 +1,6 @@
 from mollie.api.objects.chargeback import Chargeback
-from mollie.api.objects.list import List
+
+from .utils import assert_list_object
 
 PAYMENT_ID = 'tr_7UhSN1zuXS'
 CHARGEBACK_ID = 'chb_n9z0tp'
@@ -10,19 +11,7 @@ def test_get_payment_chargebacks_by_payment_id(client, response):
     response.get('https://api.mollie.com/v2/payments/%s/chargebacks' % PAYMENT_ID, 'chargebacks_list')
 
     chargebacks = client.payment_chargebacks.with_parent_id(PAYMENT_ID).list()
-    assert isinstance(chargebacks, List)
-    assert chargebacks.count == 1
-
-    iterated = 0
-    iterated_chargeback_ids = []
-    for chargeback in chargebacks:
-        assert isinstance(chargeback, Chargeback)
-        assert chargeback.id is not None
-        iterated += 1
-        iterated_chargeback_ids.append(chargeback.id)
-    assert iterated == chargebacks.count, 'Unexpected amount of chargebacks retrieved'
-    assert len(set(iterated_chargeback_ids)) == chargebacks.count, \
-        'Unexpected amount of unique chargeback ids retrieved'
+    assert_list_object(chargebacks, Chargeback)
 
 
 def test_get_single_payment_chargeback(client, response):
@@ -47,19 +36,7 @@ def test_get_all_payment_chargebacks_by_payment_object(client, response):
 
     payment = client.payments.get(PAYMENT_ID)
     chargebacks = client.payment_chargebacks.on(payment).list()
-    assert isinstance(chargebacks, List)
-    assert chargebacks.count == 1
-
-    iterated = 0
-    iterated_chargeback_ids = []
-    for chargeback in chargebacks:
-        assert isinstance(chargeback, Chargeback)
-        assert chargeback.id is not None
-        iterated += 1
-        iterated_chargeback_ids.append(chargeback.id)
-    assert iterated == chargebacks.count, 'Unexpected amount of chargebacks retrieved'
-    assert len(
-        set(iterated_chargeback_ids)) == chargebacks.count, 'Unexpected amount of unique chargeback ids retrieved'
+    assert_list_object(chargebacks, Chargeback)
 
 
 def test_get_single_payment_chargeback_by_payment_object(client, response):

--- a/tests/test_payment_chargebacks.py
+++ b/tests/test_payment_chargebacks.py
@@ -5,11 +5,11 @@ PAYMENT_ID = 'tr_7UhSN1zuXS'
 CHARGEBACK_ID = 'chb_n9z0tp'
 
 
-def test_get_payment_chargeback_by_payment_id(client, response):
+def test_get_payment_chargebacks_by_payment_id(client, response):
     """Get chargebacks relevant to payment by payment id."""
     response.get('https://api.mollie.com/v2/payments/%s/chargebacks' % PAYMENT_ID, 'chargebacks_list')
 
-    chargebacks = client.payment_chargebacks.with_parent_id(PAYMENT_ID).all()
+    chargebacks = client.payment_chargebacks.with_parent_id(PAYMENT_ID).list()
     assert isinstance(chargebacks, List)
     assert chargebacks.count == 1
 
@@ -46,7 +46,7 @@ def test_get_all_payment_chargebacks_by_payment_object(client, response):
     response.get('https://api.mollie.com/v2/payments/%s' % PAYMENT_ID, 'payment_single')
 
     payment = client.payments.get(PAYMENT_ID)
-    chargebacks = client.payment_chargebacks.on(payment).all()
+    chargebacks = client.payment_chargebacks.on(payment).list()
     assert isinstance(chargebacks, List)
     assert chargebacks.count == 1
 

--- a/tests/test_payment_refunds.py
+++ b/tests/test_payment_refunds.py
@@ -69,13 +69,13 @@ def test_get_single_refund_on_payment_object(client, response):
     assert refund.id == REFUND_ID
 
 
-def test_get_all_refunds_on_payment_object(client, response):
+def test_list_refunds_on_payment_object(client, response):
     """Retrieve all payment refunds of a payment."""
     response.get('https://api.mollie.com/v2/payments/%s' % PAYMENT_ID, 'payment_single')
     response.get('https://api.mollie.com/v2/payments/%s/refunds' % PAYMENT_ID, 'refunds_list')
 
     payment = client.payments.get(PAYMENT_ID)
-    refunds = client.payment_refunds.on(payment).all()
+    refunds = client.payment_refunds.on(payment).list()
     assert isinstance(refunds, List)
     assert refunds.count == 1
 

--- a/tests/test_payment_refunds.py
+++ b/tests/test_payment_refunds.py
@@ -1,6 +1,7 @@
-from mollie.api.objects.list import List
 from mollie.api.objects.payment import Payment
 from mollie.api.objects.refund import Refund
+
+from .utils import assert_list_object
 
 PAYMENT_ID = 'tr_7UhSN1zuXS'
 REFUND_ID = 're_4qqhO89gsT'
@@ -76,18 +77,7 @@ def test_list_refunds_on_payment_object(client, response):
 
     payment = client.payments.get(PAYMENT_ID)
     refunds = client.payment_refunds.on(payment).list()
-    assert isinstance(refunds, List)
-    assert refunds.count == 1
-
-    iterated = 0
-    iterated_refund_ids = []
-    for refund in refunds:
-        assert isinstance(refund, Refund)
-        assert refund.id is not None
-        iterated += 1
-        iterated_refund_ids.append(refund.id)
-    assert iterated == refunds.count, 'Unexpected amount of refunds retrieved'
-    assert len(set(iterated_refund_ids)) == refunds.count, 'Unexpected amount of unique refund ids retrieved'
+    assert_list_object(refunds, Refund)
 
 
 def test_cancel_refund(client, response):

--- a/tests/test_payment_refunds.py
+++ b/tests/test_payment_refunds.py
@@ -71,7 +71,7 @@ def test_get_single_refund_on_payment_object(client, response):
 
 
 def test_list_refunds_on_payment_object(client, response):
-    """Retrieve all payment refunds of a payment."""
+    """Retrieve a list of payment refunds of a payment."""
     response.get('https://api.mollie.com/v2/payments/%s' % PAYMENT_ID, 'payment_single')
     response.get('https://api.mollie.com/v2/payments/%s/refunds' % PAYMENT_ID, 'refunds_list')
 

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -3,12 +3,13 @@ import pytest
 from mollie.api.error import IdentifierError
 from mollie.api.objects.chargeback import Chargeback
 from mollie.api.objects.customer import Customer
-from mollie.api.objects.list import List
 from mollie.api.objects.mandate import Mandate
 from mollie.api.objects.method import Method
 from mollie.api.objects.payment import Payment
 from mollie.api.objects.refund import Refund
 from mollie.api.objects.subscription import Subscription
+
+from .utils import assert_list_object
 
 PAYMENT_ID = 'tr_7UhSN1zuXS'
 REFUND_ID = 're_4qqhO89gsT'
@@ -24,18 +25,7 @@ def test_list_payments(client, response):
     response.get('https://api.mollie.com/v2/payments', 'payments_list')
 
     payments = client.payments.list()
-    assert isinstance(payments, List)
-    assert payments.count == 3
-
-    iterated = 0
-    iterated_payment_ids = []
-    for payment in payments:
-        assert isinstance(payment, Payment)
-        assert payment.id is not None
-        iterated += 1
-        iterated_payment_ids.append(payment.id)
-    assert iterated == payments.count, 'Unexpected amount of payments retrieved'
-    assert len(set(iterated_payment_ids)) == payments.count, 'Unexpected unique payment ids retrieved'
+    assert_list_object(payments, Payment)
 
 
 def test_create_payment(client, response):
@@ -144,18 +134,7 @@ def test_payment_get_related_refunds(client, response):
 
     payment = client.payments.get(PAYMENT_ID)
     refunds = payment.refunds
-    assert isinstance(refunds, List)
-    assert refunds.count == 1
-
-    iterated = 0
-    iterated_refund_ids = []
-    for refund in refunds:
-        assert isinstance(refund, Refund)
-        iterated += 1
-        assert refund.id is not None
-        iterated_refund_ids.append(refund.id)
-    assert iterated == refunds.count, 'Unexpected amount of refunds retrieved'
-    assert len(set(iterated_refund_ids)) == refunds.count, 'Expected unique refund ids retrieved'
+    assert_list_object(refunds, Refund)
 
 
 def test_payment_get_related_chargebacks(client, response):
@@ -165,13 +144,7 @@ def test_payment_get_related_chargebacks(client, response):
 
     payment = client.payments.get(PAYMENT_ID)
     chargebacks = payment.chargebacks
-
-    assert isinstance(chargebacks, List)
-    iterated = 0
-    for chargeback in chargebacks:
-        assert isinstance(chargeback, Chargeback)
-        iterated += 1
-    assert iterated == chargebacks.count
+    assert_list_object(chargebacks, Chargeback)
 
 
 @pytest.mark.xfail(strict=True, reason="Settlement API is not yet implemented")

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -19,11 +19,11 @@ MANDATE_ID = 'mdt_h3gAaD5zP'
 SUBSCRIPTION_ID = 'sub_rVKGtNd6s3'
 
 
-def test_get_all_payments(client, response):
-    """Retrieve all existing payments."""
+def test_list_payments(client, response):
+    """Retrieve a list of payments."""
     response.get('https://api.mollie.com/v2/payments', 'payments_list')
 
-    payments = client.payments.all()
+    payments = client.payments.list()
     assert isinstance(payments, List)
     assert payments.count == 3
 
@@ -64,7 +64,7 @@ def test_cancel_payment(client, response):
     assert canceled_payment.id == PAYMENT_ID
 
 
-def test_cancel_paymanet_invalid_id(client):
+def test_cancel_payment_invalid_id(client):
     """Verify that an invalid payment id is validated and an error is raised."""
     with pytest.raises(IdentifierError):
         client.payments.delete('invalid')
@@ -138,7 +138,7 @@ def test_get_single_payment(client, response):
 
 
 def test_payment_get_related_refunds(client, response):
-    """Retrieve a list of all refunds related to a payment."""
+    """Retrieve a list of refunds related to a payment."""
     response.get('https://api.mollie.com/v2/payments/%s' % PAYMENT_ID, 'payment_single')
     response.get('https://api.mollie.com/v2/payments/%s/refunds' % PAYMENT_ID, 'refunds_list')
 

--- a/tests/test_refunds.py
+++ b/tests/test_refunds.py
@@ -2,10 +2,10 @@ from mollie.api.objects.list import List
 from mollie.api.objects.refund import Refund
 
 
-def test_list_all_refunds(client, response):
-    """Retrieve a list of all refunds."""
+def test_list_refunds(client, response):
+    """Retrieve a list of refunds."""
     response.get('https://api.mollie.com/v2/refunds', 'refunds_list')
-    refunds = client.refunds.all()
+    refunds = client.refunds.list()
     assert refunds.count == 1
     assert isinstance(refunds, List)
 

--- a/tests/test_refunds.py
+++ b/tests/test_refunds.py
@@ -1,20 +1,10 @@
-from mollie.api.objects.list import List
 from mollie.api.objects.refund import Refund
+
+from .utils import assert_list_object
 
 
 def test_list_refunds(client, response):
     """Retrieve a list of refunds."""
     response.get('https://api.mollie.com/v2/refunds', 'refunds_list')
     refunds = client.refunds.list()
-    assert refunds.count == 1
-    assert isinstance(refunds, List)
-
-    iterated = 0
-    iterated_refund_ids = []
-    for refund in refunds:
-        assert isinstance(refund, Refund)
-        iterated += 1
-        assert refund.id is not None
-        iterated_refund_ids.append(refund.id)
-    assert iterated == refunds.count, 'Unexpected amount of refunds retrieved'
-    assert len(set(iterated_refund_ids)) == refunds.count, 'Unexpected unique refund ids retrieved'
+    assert_list_object(refunds, Refund)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,18 +1,18 @@
 from mollie.api.objects.list import List
 
 
-def assert_list_object(list, object_type):
+def assert_list_object(obj, object_type):
     """Assert that a List object is correctly working, and has sane contents."""
-    assert isinstance(list, List), 'Object {obj} is not a List instance.'.format(obj=list)
-    assert isinstance(list.count, int), 'List count is not an integer.'
-    assert list.count > 0
+    assert isinstance(obj, List), 'Object {obj} is not a List instance.'.format(obj=obj)
+    assert isinstance(obj.count, int), 'List count is not an integer.'
+    assert obj.count > 0
 
     # verify items in list
     items = []
-    for item in list:
+    for item in obj:
         assert isinstance(item, object_type)
         assert item.id is not None
         items.append(item.id)
 
-    assert len(items) == list.count, "Items in list don't match list count."
-    assert len(set(items)) == list.count, 'Not all object ids in the list are unique.'
+    assert len(items) == obj.count, "Items in list don't match list count."
+    assert len(set(items)) == obj.count, 'Not all object ids in the list are unique.'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,18 @@
+from mollie.api.objects.list import List
+
+
+def assert_list_object(list, object_type):
+    """Assert that a List object is correctly working, and has sane contents."""
+    assert isinstance(list, List), 'Object {obj} is not a List instance.'.format(obj=list)
+    assert isinstance(list.count, int), 'List count is not an integer.'
+    assert list.count > 0
+
+    # verify items in list
+    items = []
+    for item in list:
+        assert isinstance(item, object_type)
+        assert item.id is not None
+        items.append(item.id)
+
+    assert len(items) == list.count, "Items in list don't match list count."
+    assert len(set(items)) == list.count, 'Not all object ids in the list are unique.'


### PR DESCRIPTION
Addressing https://github.com/mollie/mollie-api-python/pull/45#discussion_r208945541
- Renamed `.all()` to `.list()`
- Updated all tests
- Removed lots of code duplication in tests to determine correct behaviour of returned lists
- Fixed small bug in list handling that surfaced when iterating over a list twice.

Merge #51 first please