### PR TITLE
Unicode responses

### DIFF
--- a/mollie/api/error.py
+++ b/mollie/api/error.py
@@ -1,8 +1,22 @@
+import sys
+
+
 class Error(Exception):
     """Base exception."""
 
     def __init__(self, message):
         Exception.__init__(self, message)
+
+    def __str__(self):
+        """
+        Customize string repesentation in Python 2.
+
+        We can't have string representation containing unicode characters in Python 2.
+        """
+        if sys.version_info.major == 2:
+            return self.message.encode('ascii', errors='ignore')
+        else:
+            return super(Error, self).__str__()
 
 
 class RequestError(Error):

--- a/mollie/api/resources/base.py
+++ b/mollie/api/resources/base.py
@@ -72,6 +72,8 @@ class Base(object):
 
     def perform_api_call(self, http_method, path, data=None, params=None):
         resp = self.client.perform_http_call(http_method, path, data, params)
+        # Mollie returns unicode data in responses, but doesn't set the Content-Type header correctly
+        resp.encoding = 'utf-8'
         try:
             result = resp.json() if resp.status_code != 204 else {}
         except Exception:

--- a/mollie/api/resources/base.py
+++ b/mollie/api/resources/base.py
@@ -72,8 +72,9 @@ class Base(object):
 
     def perform_api_call(self, http_method, path, data=None, params=None):
         resp = self.client.perform_http_call(http_method, path, data, params)
-        # Mollie returns unicode data in responses, but doesn't set the Content-Type header correctly
-        resp.encoding = 'utf-8'
+        if 'application/hal+json' in resp.headers.get('Content-Type', ''):
+            # set the content type according to the media type definition
+            resp.encoding = 'utf-8'
         try:
             result = resp.json() if resp.status_code != 204 else {}
         except Exception:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,22 +22,22 @@ class ImprovedRequestsMock(responses.RequestsMock):
     def get(self, url, filename, status=200):
         """Setup a mock response for a GET request."""
         body = self._get_body(filename)
-        self.add(responses.GET, url, body=body, status=status)
+        self.add(responses.GET, url, body=body, status=status, content_type='application/hal+json')
 
     def post(self, url, filename, status=200):
         """Setup a mock response for a POST request."""
         body = self._get_body(filename)
-        self.add(responses.POST, url, body=body, status=status)
+        self.add(responses.POST, url, body=body, status=status, content_type='application/hal+json')
 
     def delete(self, url, filename, status=204):
         """Setup a mock response for a DELETE request."""
         body = self._get_body(filename)
-        self.add(responses.DELETE, url, body=body, status=status)
+        self.add(responses.DELETE, url, body=body, status=status, content_type='application/hal+json')
 
     def patch(self, url, filename, status=200):
         """Setup a mock response for a PATCH request."""
         body = self._get_body(filename)
-        self.add(responses.PATCH, url, body=body, status=status)
+        self.add(responses.PATCH, url, body=body, status=status, content_type='application/hal+json')
 
     def _get_body(self, filename):
         """Read the response fixture file and return it."""

--- a/tests/responses/order_error.json
+++ b/tests/responses/order_error.json
@@ -1,0 +1,12 @@
+{
+  "status": 422,
+  "title": "Unprocessable Entity",
+  "detail": "Order line 1 is invalid. VAT amount is off. Expected VAT amount to be €3.47 (21.00% over €20.00), got €3.10",
+  "field": "lines.1.vatAmount",
+  "_links": {
+    "documentation": {
+      "href": "https://docs.mollie.com/guides/handling-errors",
+      "type": "text/html"
+    }
+  }
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -222,7 +222,7 @@ def test_client_unicode_error_py2(client, response):
         # actual POST data for creating an order can be found in test_orders.py
         client.orders.create({})
 
-    # handling the error should work even when utf-8 characters are in the response.
+    # handling the error should work even when utf-8 characters (€) are in the response.
     exception = err.value
     expected = 'Order line 1 is invalid. VAT amount is off. ' \
         'Expected VAT amount to be 3.47 (21.00% over 20.00), got 3.10'
@@ -237,7 +237,7 @@ def test_client_unicode_error_py3(client, response):
         # actual POST data for creating an order can be found in test_orders.py
         client.orders.create({})
 
-    # handling the error should work even when utf-8 characters are in the response.
+    # handling the error should work even when utf-8 characters (€) are in the response.
     exception = err.value
     expected = 'Order line 1 is invalid. VAT amount is off. ' \
         'Expected VAT amount to be €3.47 (21.00% over €20.00), got €3.10'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -208,3 +208,16 @@ def test_client_error_including_field_response(client, response):
         client.payments.create(**params)
     assert excinfo.match('The amount is higher than the maximum')
     assert excinfo.value.field == 'amount'
+
+
+def test_client_unicode_error(client, response):
+    """An error response containing Unicode characters should also be processed correctly."""
+    response.post('https://api.mollie.com/v2/orders', 'order_error', status=422)
+    with pytest.raises(UnprocessableEntityError) as err:
+        # actual POST data for creating an order can be found in test_orders.py
+        client.orders.create({})
+
+    # printing the result should work even when utf-8 characters are in the response.
+    expected = "UnprocessableEntityError('Order line 1 is invalid. VAT amount is off. Expected VAT amount " \
+               "to be €3.47 (21.00% over €20.00), got €3.10',)"
+    assert repr(err.value) == expected


### PR DESCRIPTION
Working around the fact that Mollie sends UTF-8 responses, but doesn't set the HTTP Content-type headers to reflect this (which results in UnicodeDecodeErrors further down the line)