### PR TITLE
Setup version in one location

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ python -m virtualenv env
 $ source env/bin/activate
 ```
 
-Install the requirements, then install Mollie itself.
+Install the additional requirements for the examples, then install the Mollie API client itself.
 ```
 $ pip install flask
 $ pip install -e .

--- a/mollie/api/client.py
+++ b/mollie/api/client.py
@@ -18,6 +18,7 @@ from .resources.payment_chargebacks import PaymentChargebacks
 from .resources.payment_refunds import PaymentRefunds
 from .resources.payments import Payments
 from .resources.refunds import Refunds
+from .version import VERSION
 
 try:
     from urllib.parse import urlencode
@@ -27,7 +28,7 @@ except ImportError:
 
 
 class Client(object):
-    CLIENT_VERSION = '2.0.6'
+    CLIENT_VERSION = VERSION
     API_ENDPOINT = 'https://api.mollie.com'
     API_VERSION = 'v2'
     UNAME = ' '.join(platform.uname())

--- a/mollie/api/version.py
+++ b/mollie/api/version.py
@@ -1,0 +1,7 @@
+# In this file the version of the package is defined.
+
+# Don't change the syntax of the definition unless you know what you're doing, because this file is
+# processed by python imports and by regular expressions. The version is defined as a string in the
+# regular semantic versioning scheme (major,minor,patch).
+
+VERSION = '2.0.6'

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,43 @@
 import os.path
+import re
 
 from setuptools import find_packages, setup
 
+ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
+
 
 def get_long_description():
-    root_dir = os.path.abspath(os.path.dirname(__file__))
     try:
-        readme = open(os.path.join(root_dir, 'README.md'), encoding='utf-8')
+        readme = open(os.path.join(ROOT_DIR, 'README.md'), encoding='utf-8')
     except TypeError:
         # support python 2
-        readme = open(os.path.join(root_dir, 'README.md'))
+        readme = open(os.path.join(ROOT_DIR, 'README.md'))
     long_description = readme.read()
     return long_description
 
 
+def get_version():
+    """
+    Read the version from a file (mollie/api/version.py) in the repository.
+
+    We can't import here since we might import from an installed version.
+    """
+    try:
+        version_file = open(os.path.join(ROOT_DIR, 'mollie', 'api', 'version.py'), encoding='utf=8')
+    except TypeError:
+        # support python 2
+        version_file = open(os.path.join(ROOT_DIR, 'mollie', 'api', 'version.py'))
+    contents = version_file.read()
+    match = re.search(r'VERSION = [\'"]([^\'"]+)', contents)
+    if match:
+        return match.group(1)
+    else:
+        raise RuntimeError("Can't determine package version")
+
+
 setup(
     name='mollie-api-python',
-    version='2.0.6',
+    version=get_version(),
     license='BSD',
     long_description=get_long_description(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author='Mollie B.V.',
     author_email='info@mollie.com',
     maintainer='Four Digits B.V.',
-    mainatiner_email='info@fourdigits.nl',
+    maintainer_email='info@fourdigits.nl',
     keywords=['mollie', 'payment', 'service', 'ideal', 'creditcard', 'mistercash', 'bancontact', 'sofort',
               'sofortbanking', 'sepa', 'bitcoin', 'paypal', 'paysafecard', 'podiumcadeaukaart', 'banktransfer',
               'direct debit', 'belfius', 'belfius direct net', 'kbc', 'cbc', 'refunds', 'payments', 'gateway',


### PR DESCRIPTION
A fix for #78 

I tested installing this using:
- `pip install <path to sdist tar.gz>`
- `pip install -e <path to github repo>`
- `pip install -e <path to local checkout>`

In all versions, pip understands which version was installed.