### PR TITLE
Test with python 3.7, switch to xenial distro because trusty doesn't …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
+dist: xenial
 
 python:
   - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 install:
   - pip install --upgrade 'pip<=18.0'  # see https://github.com/pypa/pipenv/issues/2924


### PR DESCRIPTION
…support python 3.7 + ssl.

Ref: https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905