### PR TITLE
The automatic installation of numpy by travis-ci causes a security error. Ignore this

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test: develop
 	pipenv run pyflakes .
 	pipenv run pycodestyle
 	pipenv run isort --recursive --check-only
-	pipenv check
+	pipenv check --ignore 36810
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
At the moment the travis-ci build fails because of numpy:

> 36810: numpy <=1.16.0 resolved (1.16.0 installed)!
> An issue was discovered in NumPy 1.16.0 and earlier. It uses the pickle Python module unsafely, which allows remote attackers to execute arbitrary code via a crafted serialized object, as demonstrated by a numpy.load call.

We aren't using numpy, so ignoring this will solve the build failure.