### PR TITLE
Refactor use client not _resource

### DIFF
--- a/mollie/api/objects/base.py
+++ b/mollie/api/objects/base.py
@@ -1,12 +1,9 @@
 class Base(dict):
-    def __init__(self, data, resource=None, client=None):
+    def __init__(self, data, client=None):
         """
         Create a new object from API result data.
-
-        TODO: remove self._resource when all of its usage is refactored to using self.client
         """
         super(Base, self).__init__(data)
-        self._resource = resource
         self.client = client
 
     def _get_property(self, name):

--- a/mollie/api/objects/customer.py
+++ b/mollie/api/objects/customer.py
@@ -1,5 +1,4 @@
 from .base import Base
-from .list import List
 
 
 class Customer(Base):
@@ -43,26 +42,14 @@ class Customer(Base):
     @property
     def subscriptions(self):
         """Return the subscription list for the customer."""
-        from .subscription import Subscription
-        url = self._get_link('subscriptions')
-        if url:
-            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-            return List(resp, Subscription)
+        return self.client.customer_subscriptions.on(self).list()
 
     @property
     def mandates(self):
         """Return the mandate list for the customer."""
-        from .mandate import Mandate  # work around circular import
-        url = self._get_link('mandates')
-        if url:
-            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-            return List(resp, Mandate)
+        return self.client.customer_mandates.on(self).list()
 
     @property
     def payments(self):
         """Return the payment list for the customer."""
-        from .payment import Payment  # work around circular import
-        url = self._get_link('payments')
-        if url:
-            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-            return List(resp, Payment)
+        return self.client.customer_payments.on(self).list()

--- a/mollie/api/objects/list.py
+++ b/mollie/api/objects/list.py
@@ -5,7 +5,7 @@ class List(Base):
     current = None
 
     def __init__(self, result, object_type, client=None):
-        super(List, self).__init__(result, client=client)
+        super(List, self).__init__(result, client)
         self.object_type = object_type
 
     def __len__(self):
@@ -25,7 +25,7 @@ class List(Base):
             self.current += 1
         try:
             item = self['_embedded'][self.object_type.get_object_name()][self.current]
-            return self.object_type(item, client=self.client)
+            return self.object_type(item, self.client)
         except IndexError:
             self.current = None
             raise StopIteration
@@ -51,11 +51,11 @@ class List(Base):
         url = self._get_link('next')
         resource = self.object_type.get_resource_class(self.client)
         resp = resource.perform_api_call(resource.REST_READ, url)
-        return List(resp, self.object_type, client=self.client)
+        return List(resp, self.object_type, self.client)
 
     def get_previous(self):
         """Return the previous set of objects in a list"""
         url = self._get_link('previous')
         resource = self.object_type.get_resource_class(self.client)
         resp = resource.perform_api_call(resource.REST_READ, url)
-        return List(resp, self.object_type, client=self.client)
+        return List(resp, self.object_type, self.client)

--- a/mollie/api/objects/mandate.py
+++ b/mollie/api/objects/mandate.py
@@ -61,5 +61,5 @@ class Mandate(Base):
         from .customer import Customer  # work around circular imports
         url = self._get_link('customer')
         if url:
-            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
+            resp = self.client.customers.perform_api_call(self.client.customers.REST_READ, url)
             return Customer(resp)

--- a/mollie/api/objects/order.py
+++ b/mollie/api/objects/order.py
@@ -182,7 +182,7 @@ class Order(Base):
             },
             'count': len(lines),
         }
-        return List(result, OrderLine, client=self.client)
+        return List(result, OrderLine, self.client)
 
     @property
     def shipments(self):

--- a/mollie/api/objects/payment.py
+++ b/mollie/api/objects/payment.py
@@ -1,5 +1,4 @@
 from .base import Base
-from .list import List
 
 
 class Payment(Base):
@@ -159,59 +158,36 @@ class Payment(Base):
     @property
     def refunds(self):
         """Return the refunds related to this payment."""
-        from .refund import Refund
-        url = self._get_link('refunds')
-        if url:
-            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-            return List(resp, Refund)
+        return self.client.payment_refunds.on(self).list()
 
     @property
     def chargebacks(self):
         """Return the chargebacks related to this payment."""
-        from .chargeback import Chargeback
-        url = self._get_link('chargebacks')
-        if url:
-            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-            return List(resp, Chargeback)
+        return self.client.payment_chargebacks.on(self).list()
 
-    @property
-    def settlement(self):
-        """
-        Return the settlement for this payment.
+    # @property
+    # def settlement(self):
+    #     """
+    #     Return the settlement for this payment.
 
-        TODO: Before we can return a Settlement object, we need to implement the Settlement API.
-        """
-        url = self._get_link('settlement')
-        if url:
-            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-            return resp
+    #     TODO: Before we can return a Settlement object, we need to implement the Settlement API.
+    #     """
+    #     pass
 
     @property
     def mandate(self):
         """Return the mandate for this payment."""
-        from .mandate import Mandate
-        url = self._get_link('mandate')
-        if url:
-            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-            return Mandate(resp)
+        return self.client.customer_mandates.with_parent_id(self.customer_id).get(self.mandate_id)
 
     @property
     def subscription(self):
         """Return the subscription for this payment."""
-        from .subscription import Subscription
-        url = self._get_link('subscription')
-        if url:
-            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-            return Subscription(resp)
+        return self.client.customer_subscriptions.with_parent_id(self.customer_id).get(self.subscription_id)
 
     @property
     def customer(self):
         """Return the customer for this payment."""
-        from .customer import Customer
-        url = self._get_link('customer')
-        if url:
-            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-            return Customer(resp)
+        return self.client.customers.get(self.customer_id)
 
     @property
     def order(self):
@@ -219,7 +195,7 @@ class Payment(Base):
         from ..resources.orders import Order
         url = self._get_link('order')
         if url:
-            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
+            resp = self.client.orders.perform_api_call(self.client.orders.REST_READ, url)
             return Order(resp, client=self.client)
 
     # additional methods

--- a/mollie/api/objects/payment.py
+++ b/mollie/api/objects/payment.py
@@ -196,7 +196,7 @@ class Payment(Base):
         url = self._get_link('order')
         if url:
             resp = self.client.orders.perform_api_call(self.client.orders.REST_READ, url)
-            return Order(resp, client=self.client)
+            return Order(resp, self.client)
 
     # additional methods
 

--- a/mollie/api/objects/refund.py
+++ b/mollie/api/objects/refund.py
@@ -69,33 +69,21 @@ class Refund(Base):
     @property
     def payment(self):
         """Return the payment for this refund."""
-        from .payment import Payment
-        url = self._get_link('payment')
-        if url:
-            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-            return Payment(resp)
+        return self.client.payments.get(self.payment_id)
 
-    @property
-    def settlement(self):
-        """
-        Return the settlement for this refund.
+    # @property
+    # def settlement(self):
+    #     """
+    #     Return the settlement for this refund.
 
-        TODO: Before we can return an Settlement object, we need to implement the Setlement API.
-        """
-        url = self._get_link('settlement')
-        if url:
-            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-            return resp
+    #     TODO: Before we can return an Settlement object, we need to implement the Setlement API.
+    #     """
+    #     pass
 
     @property
     def order(self):
         """Return the order for this refund."""
-        from ..resources.orders import Order
-
-        url = self._get_link('order')
-        if url:
-            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-            return Order(resp, client=self.client)
+        return self.client.orders.get(self.order_id)
 
     # additional methods
 

--- a/mollie/api/objects/refund.py
+++ b/mollie/api/objects/refund.py
@@ -50,7 +50,7 @@ class Refund(Base):
             },
             'count': len(lines),
         }
-        return List(result, OrderLine, client=self.client)
+        return List(result, OrderLine, self.client)
 
     @property
     def payment_id(self):

--- a/mollie/api/objects/shipment.py
+++ b/mollie/api/objects/shipment.py
@@ -38,7 +38,7 @@ class Shipment(Base):
             },
             'count': len(lines),
         }
-        return List(result, OrderLine, client=self.client)
+        return List(result, OrderLine, self.client)
 
     @property
     def order(self):

--- a/mollie/api/objects/subscription.py
+++ b/mollie/api/objects/subscription.py
@@ -86,5 +86,5 @@ class Subscription(Base):
         """Return the customer for this subscription."""
         url = self._get_link('customer')
         if url:
-            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
+            resp = self.client.customers.perform_api_call(self.client.customers.REST_READ, url)
             return Customer(resp)

--- a/mollie/api/resources/base.py
+++ b/mollie/api/resources/base.py
@@ -41,7 +41,7 @@ class Base(object):
     def list(self, **params):
         path = self.get_resource_name()
         result = self.perform_api_call(self.REST_LIST, path, params=params)
-        return List(result, self.get_resource_object({}).__class__, client=self.client)
+        return List(result, self.get_resource_object({}).__class__, self.client)
 
     def perform_api_call(self, http_method, path, data=None, params=None):
         resp = self.client.perform_http_call(http_method, path, data, params)

--- a/mollie/api/resources/customer_mandates.py
+++ b/mollie/api/resources/customer_mandates.py
@@ -8,7 +8,7 @@ class CustomerMandates(Base):
     customer_id = None
 
     def get_resource_object(self, result):
-        return Mandate(result, client=self.client)
+        return Mandate(result, self.client)
 
     def get(self, mandate_id, **params):
         if not mandate_id or not mandate_id.startswith(self.RESOURCE_ID_PREFIX):

--- a/mollie/api/resources/customer_mandates.py
+++ b/mollie/api/resources/customer_mandates.py
@@ -8,7 +8,7 @@ class CustomerMandates(Base):
     customer_id = None
 
     def get_resource_object(self, result):
-        return Mandate(result, self)
+        return Mandate(result, client=self.client)
 
     def get(self, mandate_id, **params):
         if not mandate_id or not mandate_id.startswith(self.RESOURCE_ID_PREFIX):

--- a/mollie/api/resources/customer_subscriptions.py
+++ b/mollie/api/resources/customer_subscriptions.py
@@ -8,7 +8,7 @@ class CustomerSubscriptions(Base):
     customer_id = None
 
     def get_resource_object(self, result):
-        return Subscription(result, self)
+        return Subscription(result, client=self.client)
 
     def get(self, subscription_id, **params):
         if not subscription_id or not subscription_id.startswith(self.RESOURCE_ID_PREFIX):

--- a/mollie/api/resources/customer_subscriptions.py
+++ b/mollie/api/resources/customer_subscriptions.py
@@ -8,7 +8,7 @@ class CustomerSubscriptions(Base):
     customer_id = None
 
     def get_resource_object(self, result):
-        return Subscription(result, client=self.client)
+        return Subscription(result, self.client)
 
     def get(self, subscription_id, **params):
         if not subscription_id or not subscription_id.startswith(self.RESOURCE_ID_PREFIX):

--- a/mollie/api/resources/customers.py
+++ b/mollie/api/resources/customers.py
@@ -7,7 +7,7 @@ class Customers(Base):
     RESOURCE_ID_PREFIX = 'cst_'
 
     def get_resource_object(self, result):
-        return Customer(result, self)
+        return Customer(result, client=self.client)
 
     def get(self, customer_id, **params):
         if not customer_id or not customer_id.startswith(self.RESOURCE_ID_PREFIX):

--- a/mollie/api/resources/customers.py
+++ b/mollie/api/resources/customers.py
@@ -7,7 +7,7 @@ class Customers(Base):
     RESOURCE_ID_PREFIX = 'cst_'
 
     def get_resource_object(self, result):
-        return Customer(result, client=self.client)
+        return Customer(result, self.client)
 
     def get(self, customer_id, **params):
         if not customer_id or not customer_id.startswith(self.RESOURCE_ID_PREFIX):

--- a/mollie/api/resources/order_lines.py
+++ b/mollie/api/resources/order_lines.py
@@ -9,7 +9,7 @@ class OrderLines(Base):
         return 'orders/{order_id}/lines'.format(order_id=self.order_id)
 
     def get_resource_object(self, result):
-        return OrderLine(result, client=self.client)
+        return OrderLine(result, self.client)
 
     def with_parent_id(self, order_id):
         self.order_id = order_id

--- a/mollie/api/resources/orders.py
+++ b/mollie/api/resources/orders.py
@@ -7,7 +7,7 @@ class Orders(Base):
     RESOURCE_ID_PREFIX = 'ord_'
 
     def get_resource_object(self, result):
-        return Order(result, client=self.client)
+        return Order(result, self.client)
 
     def get(self, order_id, **params):
         if not order_id or not order_id.startswith(self.RESOURCE_ID_PREFIX):

--- a/mollie/api/resources/payments.py
+++ b/mollie/api/resources/payments.py
@@ -7,7 +7,7 @@ class Payments(Base):
     RESOURCE_ID_PREFIX = 'tr_'
 
     def get_resource_object(self, result):
-        return Payment(result, client=self.client)
+        return Payment(result, self.client)
 
     def get(self, payment_id, **params):
         if not payment_id or not payment_id.startswith(self.RESOURCE_ID_PREFIX):

--- a/mollie/api/resources/payments.py
+++ b/mollie/api/resources/payments.py
@@ -7,7 +7,7 @@ class Payments(Base):
     RESOURCE_ID_PREFIX = 'tr_'
 
     def get_resource_object(self, result):
-        return Payment(result, self)
+        return Payment(result, client=self.client)
 
     def get(self, payment_id, **params):
         if not payment_id or not payment_id.startswith(self.RESOURCE_ID_PREFIX):

--- a/mollie/api/resources/refunds.py
+++ b/mollie/api/resources/refunds.py
@@ -7,7 +7,7 @@ class Refunds(Base):
     RESOURCE_ID_PREFIX = 're_'
 
     def get_resource_object(self, result):
-        return Refund(result, client=self.client)
+        return Refund(result, self.client)
 
     def get(self, refund_id, **params):
         if not refund_id or not refund_id.startswith(self.RESOURCE_ID_PREFIX):

--- a/mollie/api/resources/refunds.py
+++ b/mollie/api/resources/refunds.py
@@ -7,7 +7,7 @@ class Refunds(Base):
     RESOURCE_ID_PREFIX = 're_'
 
     def get_resource_object(self, result):
-        return Refund(result, self)
+        return Refund(result, client=self.client)
 
     def get(self, refund_id, **params):
         if not refund_id or not refund_id.startswith(self.RESOURCE_ID_PREFIX):

--- a/mollie/api/resources/shipments.py
+++ b/mollie/api/resources/shipments.py
@@ -6,7 +6,7 @@ class Shipments(Base):
     order_id = None
 
     def get_resource_object(self, result):
-        return Shipment(result, client=self.client)
+        return Shipment(result, self.client)
 
     def get_resource_name(self):
         return 'orders/{id}/shipments'.format(id=self.order_id)

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -53,6 +53,8 @@ def test_list_customers(client, response):
 def test_get_customer(client, response):
     """Retrieve a single customer."""
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_new')
+    response.get('https://api.mollie.com/v2/customers/%s/subscriptions' % CUSTOMER_ID, 'subscriptions_list')
+    response.get('https://api.mollie.com/v2/customers/%s/mandates' % CUSTOMER_ID, 'customer_mandates_list')
     response.get('https://api.mollie.com/v2/customers/%s/payments' % CUSTOMER_ID, 'customer_payments_multiple')
 
     customer = client.customers.get(CUSTOMER_ID)
@@ -65,8 +67,8 @@ def test_get_customer(client, response):
     assert customer.mode == 'test'
     assert customer.resource == 'customer'
     assert customer.created_at == '2018-04-06T13:10:19.0Z'
-    assert customer.subscriptions is None
-    assert customer.mandates is None
+    assert customer.subscriptions is not None
+    assert customer.mandates is not None
     assert customer.payments is not None
 
 

--- a/tests/test_payment_refunds.py
+++ b/tests/test_payment_refunds.py
@@ -31,7 +31,6 @@ def test_get_refund(client, response):
     assert refund.created_at == '2018-03-14T17:09:02.0Z'
     # properties from _links
     assert refund.payment is not None
-    assert refund.settlement is None
     assert isinstance(refund.order, Order)
     # additional methods
     assert refund.is_queued() is False

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -113,7 +113,6 @@ def test_get_single_payment(client, response):
     assert payment.checkout_url == 'https://www.mollie.com/payscreen/select-method/7UhSN1zuXS'
     assert payment.refunds is not None
     assert payment.chargebacks is not None
-    assert payment.settlement is None
     assert payment.mandate is not None
     assert payment.subscription is not None
     assert payment.customer is not None


### PR DESCRIPTION
Remove use of the `object._resource` attribute for retrieving data for related object data. Refactored everything to use the more generic `object.client` attribute.