### PR TITLE
Add support for listing subscription payments

### DIFF
--- a/mollie/api/client.py
+++ b/mollie/api/client.py
@@ -17,6 +17,7 @@ from .resources.payment_chargebacks import PaymentChargebacks
 from .resources.payment_refunds import PaymentRefunds
 from .resources.payments import Payments
 from .resources.refunds import Refunds
+from .resources.subscription_payments import SubscriptionPayments
 from .version import VERSION
 
 try:
@@ -65,6 +66,7 @@ class Client(object):
         self.customer_subscriptions = CustomerSubscriptions(self)
         self.customer_payments = CustomerPayments(self)
         self.orders = Orders(self)
+        self.subscription_payments = SubscriptionPayments(self)
 
     def set_api_endpoint(self, api_endpoint):
         self.api_endpoint = self.validate_api_endpoint(api_endpoint)

--- a/mollie/api/objects/subscription.py
+++ b/mollie/api/objects/subscription.py
@@ -88,3 +88,9 @@ class Subscription(Base):
         if url:
             resp = self.client.customers.perform_api_call(self.client.customers.REST_READ, url)
             return Customer(resp)
+
+    @property
+    def payments(self):
+        """Return a list of payments for this subscription."""
+        payments = self.client.subscription_payments.on(self).list()
+        return payments

--- a/mollie/api/resources/subscription_payments.py
+++ b/mollie/api/resources/subscription_payments.py
@@ -1,0 +1,21 @@
+from .payments import Payments
+
+
+class SubscriptionPayments(Payments):
+    customer_id = None
+    subscription_id = None
+
+    def get_resource_name(self):
+        return 'customers/{customer_id}/subscription/{subscription_id}/payments'.format(
+            customer_id=self.customer_id,
+            subscription_id=self.subscription_id,
+        )
+
+    def with_parent_id(self, customer_id, subscription_id):
+        self.customer_id = customer_id
+        self.subscription_id = subscription_id
+        return self
+
+    def on(self, subscription):
+        # TODO: A request has been filed to mollie to add the customer id to the subscription response.
+        return self.with_parent_id(subscription.customer.id, subscription.id)

--- a/tests/test_customer_subscriptions.py
+++ b/tests/test_customer_subscriptions.py
@@ -3,6 +3,7 @@ import pytest
 from mollie.api.error import IdentifierError
 from mollie.api.objects.customer import Customer
 from mollie.api.objects.method import Method
+from mollie.api.objects.payment import Payment
 from mollie.api.objects.subscription import Subscription
 
 from .utils import assert_list_object
@@ -129,3 +130,15 @@ def test_update_customer_subscription(client, response):
     subscription = client.customer_subscriptions.with_parent_id(CUSTOMER_ID).update(SUBSCRIPTION_ID, data)
     assert isinstance(subscription, Subscription)
     assert subscription.id == SUBSCRIPTION_ID
+
+
+def test_customer_subscription_get_related_payments(client, response):
+    """Retrieve a list of payments related to the subscription. """
+    response.get('https://api.mollie.com/v2/customers/%s/subscriptions/%s' % (CUSTOMER_ID, SUBSCRIPTION_ID),
+                 'subscription_single')
+    response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_single')
+    response.get('https://api.mollie.com/v2/customers/%s/subscription/%s/payments' % (CUSTOMER_ID, SUBSCRIPTION_ID),
+                 'payments_list')
+    subscription = client.customer_subscriptions.with_parent_id(CUSTOMER_ID).get(SUBSCRIPTION_ID)
+    payments = subscription.payments
+    assert_list_object(payments, Payment)


### PR DESCRIPTION
Solves issue #89 Add support for listing subscription payments

Because the `customer id` is no property of a subscription, and the subscription payments url is not in the subscription response under `_links`, we retrieve the `customer id` in the `SubscriptionPayments` resource through the `customer` object.