### PR TITLE
Add update orderline function to the order object

### DIFF
--- a/mollie/api/error.py
+++ b/mollie/api/error.py
@@ -99,3 +99,12 @@ class UnprocessableEntityError(ResponseError):
     """
 
     pass
+
+
+class DataConsistencyError(Error):
+    """
+    We could not process the API response due to an inconsistency.
+
+    We received different data than expected from the API.
+    """
+    pass

--- a/mollie/api/objects/order.py
+++ b/mollie/api/objects/order.py
@@ -1,3 +1,4 @@
+from ..resources.order_lines import OrderLines
 from ..resources.order_payments import OrderPayments
 from ..resources.order_refunds import OrderRefunds
 from ..resources.shipments import Shipments
@@ -184,6 +185,10 @@ class Order(Base):
             'count': len(lines),
         }
         return List(result, OrderLine, self.client)
+
+    def update_line(self, resource_id, data):
+        """Update a line for an order."""
+        return OrderLines(self.client).on(self).update(resource_id, data)
 
     @property
     def shipments(self):

--- a/tests/responses/order_single.json
+++ b/tests/responses/order_single.json
@@ -49,7 +49,7 @@
     {
       "resource": "orderline",
       "id": "odl_dgtxyl",
-      "orderId": "ord_pbjz8x",
+      "orderId": "ord_kEn1PlbGa",
       "name": "LEGO 42083 Bugatti Chiron",
       "sku": "5702016116977",
       "type": "physical",
@@ -106,7 +106,7 @@
     {
       "resource": "orderline",
       "id": "odl_jp31jz",
-      "orderId": "ord_pbjz8x",
+      "orderId": "ord_kEn1PlbGa",
       "name": "LEGO 42056 Porsche 911 GT3 RS",
       "sku": "5702015594028",
       "type": "physical",
@@ -159,11 +159,11 @@
   ],
   "_links": {
     "self": {
-      "href": "https://api.mollie.com/v2/orders/ord_pbjz8x",
+      "href": "https://api.mollie.com/v2/orders/ord_kEn1PlbGa",
       "type": "application/hal+json"
     },
     "checkout": {
-      "href": "https://www.mollie.com/payscreen/order/checkout/pbjz8x",
+      "href": "https://www.mollie.com/payscreen/order/checkout/kEn1PlbGa",
       "type": "text/html"
     },
     "documentation": {

--- a/tests/test_order_lines.py
+++ b/tests/test_order_lines.py
@@ -2,7 +2,7 @@ from mollie.api.objects.order_line import OrderLine
 
 from .utils import assert_list_object
 
-ORDER_ID = 'ord_pbjz8x'
+ORDER_ID = 'ord_kEn1PlbGa'
 LINE_ID = 'odl_dgtxyl'
 
 
@@ -49,3 +49,36 @@ def test_get_order_lines(client, response):
     assert line.is_shipping() is False
     assert line.is_canceled() is False
     assert line.is_completed() is False
+
+
+def test_update_order_line(client, response):
+    """Update a line by id through an order object."""
+    response.get('https://api.mollie.com/v2/orders/{order_id}'.format(order_id=ORDER_ID), 'order_single')
+    response.patch('https://api.mollie.com/v2/orders/{order_id}/lines/{order_line_id}'.format(
+        order_id=ORDER_ID, order_line_id=LINE_ID), 'order_single')
+    data = {
+        "name": "LEGO 71043 Hogwarts Castle",
+        "productUrl": "https://shop.lego.com/en-GB/product/Hogwarts-Castle-71043",
+        "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/71043_alt1?$main$",
+        "quantity": 2,
+        "vatRate": "21.00",
+        "unitPrice": {
+            "currency": "EUR",
+            "value": "349.00"
+        },
+        "totalAmount": {
+            "currency": "EUR",
+            "value": "598.00"
+        },
+        "discountAmount": {
+            "currency": "EUR",
+            "value": "100.00"
+        },
+        "vatAmount": {
+            "currency": "EUR",
+            "value": "103.79"
+        }
+    }
+    order = client.orders.get(ORDER_ID)
+    update = order.update_line(LINE_ID, data)
+    assert isinstance(update, OrderLine)

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -63,7 +63,7 @@ def test_get_order(client, response):
     assert order.authorized_at is None
     assert order.canceled_at is None
     assert order.completed_at is None
-    assert order.checkout_url == 'https://www.mollie.com/payscreen/order/checkout/pbjz8x'
+    assert order.checkout_url == 'https://www.mollie.com/payscreen/order/checkout/kEn1PlbGa'
     assert_list_object(order.shipments, Shipment)
     assert_list_object(order.refunds, Refund)
 


### PR DESCRIPTION
Solves issue #87 Add support for updating an orderline

Also create an `DataConsistencyError`, which will be raised when unexpected data is received from the API.