### PR TITLE
Add support for API endpoint that exposes all available Mollie paymen…

### DIFF
--- a/mollie/api/resources/methods.py
+++ b/mollie/api/resources/methods.py
@@ -1,3 +1,4 @@
+from ..objects.list import List
 from ..objects.method import Method
 from .base import Base
 
@@ -5,3 +6,9 @@ from .base import Base
 class Methods(Base):
     def get_resource_object(self, result):
         return Method(result)
+
+    def all(self, **params):
+        """List all mollie payment methods, including methods that aren't activated in your profile."""
+        path = 'methods/all'
+        result = self.perform_api_call(self.REST_LIST, path, params=params)
+        return List(result, self.get_resource_object({}).__class__, self.client)

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -34,3 +34,11 @@ def test_method_get_missing_images(client, response):
     assert method.image_svg is None
     assert method.image_size1x is None
     assert method.image_size2x is None
+
+
+def test_list_all_methods(client, response):
+    """List all payment methods that Mollie is offering, including inactive methods."""
+    response.get('https://api.mollie.com/v2/methods/all', 'methods_list')
+
+    methods = client.methods.all()
+    assert_list_object(methods, Method)


### PR DESCRIPTION
…tmethods.

This is mainly useful when you're developing an admin interface for Mollie settings,
and want to list the paymentmethods that Mollie supports, so the admin can enable them using
the enable/disable paymentmethod in `Client().profile_methods`.

https://github.com/mollie/mollie-api-python/issues/107