### PR TITLE
Support new API endpoint: list all subscriptions

### DIFF
--- a/mollie/api/client.py
+++ b/mollie/api/client.py
@@ -39,6 +39,7 @@ from .resources.settlement_payments import SettlementPayments
 from .resources.settlement_refunds import SettlementRefunds
 from .resources.settlements import Settlements
 from .resources.subscription_payments import SubscriptionPayments
+from .resources.subscriptions import Subscriptions
 from .version import VERSION
 
 
@@ -112,6 +113,7 @@ class Client(object):
         self.settlement_refunds = SettlementRefunds(self)
         self.settlement_chargebacks = SettlementChargebacks(self)
         self.settlement_captures = SettlementCaptures(self)
+        self.subscriptions = Subscriptions(self)
 
         # compose base user agent string
         self.user_agent_components = OrderedDict()

--- a/mollie/api/resources/subscriptions.py
+++ b/mollie/api/resources/subscriptions.py
@@ -1,0 +1,19 @@
+from ..objects.subscription import Subscription
+from .base import Base
+
+
+class Subscriptions(Base):
+    def get_resource_object(self, result):
+        return Subscription(result, self.client)
+
+    def create(self, data=None, **params):
+        raise NotImplementedError('The endpoint "create" is not supported.')
+
+    def get(self, resource_id, **params):
+        raise NotImplementedError('The endpoint "get" is not supported.')
+
+    def update(self, resource_id, data=None, **params):
+        raise NotImplementedError('The endpoint "update" is not supported.')
+
+    def delete(self, resource_id, data=None):
+        raise NotImplementedError('The endpoint "delete" is not supported.')

--- a/tests/responses/subscriptions_customer_list.json
+++ b/tests/responses/subscriptions_customer_list.json
@@ -22,10 +22,6 @@
             "href": "https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/subscriptions/sub_rVKGtNd6s3",
             "type": "application/hal+json"
           },
-          "profile": {
-            "href": "https://api.mollie.com/v2/profiles/pfl_URR55HPMGo",
-            "type": "application/hal+json"
-          },
           "customer": {
             "href": "https://api.mollie.com/v2/customers/cst_8wmqcHMN4U",
             "type": "application/hal+json"
@@ -50,10 +46,6 @@
         "_links": {
           "self": {
             "href": "https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/subscriptions/sub_rVKGtNd6s4",
-            "type": "application/hal+json"
-          },
-          "profile": {
-            "href": "https://api.mollie.com/v2/profiles/pfl_URR55HPMGy",
             "type": "application/hal+json"
           },
           "customer": {
@@ -82,10 +74,6 @@
             "href": "https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/subscriptions/sub_rVKGtNd6s5",
             "type": "application/hal+json"
           },
-          "profile": {
-            "href": "https://api.mollie.com/v2/profiles/pfl_URR55HPMGx",
-            "type": "application/hal+json"
-          },
           "customer": {
             "href": "https://api.mollie.com/v2/customers/cst_8wmqcHMN4U",
             "type": "application/hal+json"
@@ -96,16 +84,16 @@
   },
   "_links": {
     "self": {
-      "href": "https://api.mollie.com/v2/subscriptions",
+      "href": "https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/subscriptions",
       "type": "application/hal+json"
     },
     "previous": null,
     "next": {
-      "href": "https://api.mollie.com/v2/subscriptions?from=sub_mnfbwhMfvo",
+      "href": "https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/subscriptions?from=sub_mnfbwhMfvo",
       "type": "application/hal+json"
     },
     "documentation": {
-      "href": "https://docs.mollie.com/reference/v2/subscriptions-api/list-all-subscriptions",
+      "href": "https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions",
       "type": "text/html"
     }
   }

--- a/tests/test_customer_subscriptions.py
+++ b/tests/test_customer_subscriptions.py
@@ -14,7 +14,7 @@ SUBSCRIPTION_ID = 'sub_rVKGtNd6s3'
 
 def test_list_customer_subscriptions(client, response):
     """Retrieve a list of subscriptions."""
-    response.get('https://api.mollie.com/v2/customers/%s/subscriptions' % CUSTOMER_ID, 'subscriptions_list')
+    response.get('https://api.mollie.com/v2/customers/%s/subscriptions' % CUSTOMER_ID, 'subscriptions_customer_list')
 
     subscriptions = client.customer_subscriptions.with_parent_id(CUSTOMER_ID).list()
     assert_list_object(subscriptions, Subscription)
@@ -52,7 +52,7 @@ def test_list_customer_subscriptions_by_customer_object(client, response):
     """Retrieve a list of subscriptions related to customer."""
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_single')
     response.get('https://api.mollie.com/v2/customers/%s/subscriptions' % CUSTOMER_ID,
-                 'subscriptions_list')
+                 'subscriptions_customer_list')
 
     customer = client.customers.get(CUSTOMER_ID)
     subscriptions = client.customer_subscriptions.on(customer).list()

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -53,7 +53,7 @@ def test_list_customers(client, response):
 def test_get_customer(client, response):
     """Retrieve a single customer."""
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_new')
-    response.get('https://api.mollie.com/v2/customers/%s/subscriptions' % CUSTOMER_ID, 'subscriptions_list')
+    response.get('https://api.mollie.com/v2/customers/%s/subscriptions' % CUSTOMER_ID, 'subscriptions_customer_list')
     response.get('https://api.mollie.com/v2/customers/%s/mandates' % CUSTOMER_ID, 'customer_mandates_list')
     response.get('https://api.mollie.com/v2/customers/%s/payments' % CUSTOMER_ID, 'customer_payments_multiple')
 
@@ -86,7 +86,7 @@ def test_customer_get_related_subscriptions(client, response):
     """Retrieve related subscriptions for a customer."""
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_single')
     response.get('https://api.mollie.com/v2/customers/%s/subscriptions' % CUSTOMER_ID,
-                 'subscriptions_list')
+                 'subscriptions_customer_list')
 
     customer = client.customers.get(CUSTOMER_ID)
     subscriptions = customer.subscriptions

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -1,0 +1,33 @@
+import pytest
+
+from mollie.api.objects.subscription import Subscription
+
+from .utils import assert_list_object
+
+
+def test_list_customers(client, response):
+    """Retrieve a list of existing subscriptions."""
+    response.get('https://api.mollie.com/v2/subscriptions', 'subscriptions_list')
+
+    subscriptions = client.subscriptions.list()
+    assert_list_object(subscriptions, Subscription)
+
+
+def test_create_subscription(client):
+    with pytest.raises(NotImplementedError, match='The endpoint "create" is not supported.'):
+        client.subscriptions.create()
+
+
+def test_get_subscription(client):
+    with pytest.raises(NotImplementedError, match='The endpoint "get" is not supported.'):
+        client.subscriptions.get('sub_rVKGtNd6s3')
+
+
+def test_update_subscription(client):
+    with pytest.raises(NotImplementedError, match='The endpoint "update" is not supported.'):
+        client.subscriptions.update('sub_rVKGtNd6s3')
+
+
+def test_delete_subscription(client):
+    with pytest.raises(NotImplementedError, match='The endpoint "delete" is not supported.'):
+        client.subscriptions.delete('sub_rVKGtNd6s3')


### PR DESCRIPTION
A Subscription resource is added, and all the methods except `list()` will raise a `NotImplementedError`. 

Solves #141