### PR TITLE
fix: currency is displayed twice, display value instead

### DIFF
--- a/examples/05-payments-history.py
+++ b/examples/05-payments-history.py
@@ -33,7 +33,7 @@ def main():
 
         for payment in payments:
             body += "{curr} {value}, status: '{status}'<br>".format(
-                curr=payment.amount['currency'], value=payment.amount['currency'], status=payment.status)
+                curr=payment.amount['currency'], value=payment.amount['value'], status=payment.status)
 
         return body
 


### PR DESCRIPTION
The code displays twice the currency
EUR **EUR**, status: 'paid'

correct display after the commit
EUR **120.00**, status: 'paid'