### PR TITLE
Add warning about deprecated feature in Settlements API.

### DIFF
--- a/mollie/api/error.py
+++ b/mollie/api/error.py
@@ -114,3 +114,13 @@ class RemovedIn25Warning(PendingDeprecationWarning):
     """Pending deprecation warning for features that will be removed in version 2.5.0."""
 
     pass
+
+
+class APIDeprecationWarning(DeprecationWarning):
+    """
+    Features that are deprecated in the Mollie API.
+
+    This library cannot control when an API feature will be removed. We can only label it as 'deprecated'
+    using this warning, and hope that library users stop using the feature before the removal.
+    """
+    pass

--- a/mollie/api/objects/settlement.py
+++ b/mollie/api/objects/settlement.py
@@ -1,3 +1,6 @@
+import warnings
+
+from ..error import APIDeprecationWarning
 from .base import Base
 
 
@@ -42,6 +45,11 @@ class Settlement(Base):
 
     @property
     def invoice_id(self):
+        warnings.warn(
+            "Using Settlement Invoice ID is deprecated, see "
+            "https://docs.mollie.com/reference/v2/settlements-api/get-settlement",
+            APIDeprecationWarning
+        )
         return self._get_property('invoiceId')
 
     # Additional methods

--- a/tests/test_settlements.py
+++ b/tests/test_settlements.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from mollie.api.error import IdentifierError
+from mollie.api.error import APIDeprecationWarning, IdentifierError
 from mollie.api.objects.settlement import Settlement
 from mollie.api.resources.settlements import Settlements
 from tests.utils import assert_list_object
@@ -126,7 +126,6 @@ def test_settlement_get(oauth_client, response):
     assert settlement.created_at == '2018-04-06T06:00:01.0Z'
     assert settlement.settled_at == '2018-04-06T09:41:44.0Z'
     assert settlement.amount == {'currency': 'EUR', 'value': '39.75'}
-    assert settlement.invoice_id == 'inv_FrvewDA3Pr'
 
     assert settlement.status == settlement.STATUS_OPEN
     assert settlement.is_open() is True
@@ -182,3 +181,11 @@ def test_validate_settlement_id(input, expected):
             Settlements.validate_settlement_id(input)
     else:
         assert Settlements.validate_settlement_id(input) is expected
+
+
+def test_settlement_invoice_id_is_deprecated(oauth_client, response):
+    response.get('https://api.mollie.com/v2/settlements/%s' % SETTLEMENT_ID, 'settlement_single')
+
+    settlement = oauth_client.settlements.get(SETTLEMENT_ID)
+    with pytest.warns(APIDeprecationWarning, match='Using Settlement Invoice ID is deprecated'):
+        assert settlement.invoice_id == "inv_FrvewDA3Pr"


### PR DESCRIPTION
See deprecation warning for `invoiceId` at https://docs.mollie.com/reference/v2/settlements-api/get-settlement