### PR TITLE
Retry failed requests

### DIFF
--- a/mollie/api/client.py
+++ b/mollie/api/client.py
@@ -72,7 +72,7 @@ class Client(object):
                     access_token=access_token))
         return access_token
 
-    def __init__(self, api_endpoint=None, timeout=10, retry=None):
+    def __init__(self, api_endpoint=None, timeout=2, retry=None):
         self.api_endpoint = self.validate_api_endpoint(api_endpoint or self.API_ENDPOINT)
         self.api_version = self.API_VERSION
         self.timeout = timeout

--- a/mollie/api/client.py
+++ b/mollie/api/client.py
@@ -211,6 +211,7 @@ class Client(object):
                 },
                 params=params,
                 data=data,
+                timeout=self.timeout,
             )
         except requests.exceptions.RequestException as err:
             raise RequestError('Unable to communicate with Mollie: {error}'.format(error=err))

--- a/mollie/api/client.py
+++ b/mollie/api/client.py
@@ -76,8 +76,9 @@ class Client(object):
         self.api_version = self.API_VERSION
         self.timeout = timeout
         self.api_key = None
+        self._client = None
 
-        self.oauth = None
+        self._oauth_client = None
         self.client_secret = None
         self.access_token = None
         self.set_token = None
@@ -177,11 +178,16 @@ class Client(object):
     def _perform_http_call_apikey(self, http_method, path, data=None, params=None):
         if not self.api_key:
             raise RequestSetupError('You have not set an API key. Please use set_api_key() to set the API key.')
+
+        if not self._client:
+            self._client = requests.Session()
+            self._client.verify = True
+
         url, data, params = self._format_request_data(path, data, params)
         try:
-            response = requests.request(
-                http_method, url,
-                verify=True,
+            response = self._client.request(
+                method=http_method,
+                url=url,
                 headers={
                     'Accept': 'application/json',
                     'Authorization': 'Bearer {api_key}'.format(api_key=self.api_key),
@@ -200,9 +206,9 @@ class Client(object):
     def _perform_http_call_oauth(self, http_method, path, data=None, params=None):
         url, data, params = self._format_request_data(path, data, params)
         try:
-            response = self.oauth.request(
-                http_method,
-                url,
+            response = self._oauth_client.request(
+                method=http_method,
+                url=url,
                 headers={
                     'Accept': 'application/json',
                     'Content-Type': 'application/json',
@@ -218,7 +224,7 @@ class Client(object):
         return response
 
     def perform_http_call(self, http_method, path, data=None, params=None):
-        if self.oauth:
+        if self._oauth_client:
             return self._perform_http_call_oauth(http_method, path, data=data, params=params)
         else:
             return self._perform_http_call_apikey(http_method, path, data=data, params=params)
@@ -236,7 +242,7 @@ class Client(object):
         self.set_user_agent_component('OAuth', '2.0', sanitize=False)  # keep spelling equal to the PHP client
         self.set_token = set_token
         self.client_secret = client_secret
-        self.oauth = OAuth2Session(
+        self._oauth_client = OAuth2Session(
             client_id,
             auto_refresh_kwargs={
                 'client_id': client_id,
@@ -248,12 +254,14 @@ class Client(object):
             token=token,
             token_updater=set_token
         )
+        self._oauth_client.verify = True
+
         authorization_url = None
-        if not self.oauth.authorized:
-            authorization_url, state = self.oauth.authorization_url(self.OAUTH_AUTHORIZATION_URL)
+        if not self._oauth_client.authorized:
+            authorization_url, state = self._oauth_client.authorization_url(self.OAUTH_AUTHORIZATION_URL)
 
         # The merchant should visit this url to authorize access.
-        return self.oauth.authorized, authorization_url
+        return self._oauth_client.authorized, authorization_url
 
     def setup_oauth_authorization_response(self, authorization_response):
         """
@@ -261,7 +269,7 @@ class Client(object):
         :return: None
         """
         # Fetch an access token from the provider using the authorization code obtained during user authorization.
-        self.access_token = self.oauth.fetch_token(
+        self.access_token = self._oauth_client.fetch_token(
             self.OAUTH_TOKEN_URL,
             authorization_response=authorization_response,
             client_secret=self.client_secret,

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 test=pytest
 
 [tool:pytest]
+mock_use_standalone_module = true
 addopts =
     --verbose
     --cov mollie/

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,5 +3,6 @@ pytest-cov>=2.10.0
 pytest-isort
 pytest-flake8
 pytest-mock
+mock
 responses
 safety

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,6 +2,6 @@ pytest>=5.4.3
 pytest-cov>=2.10.0
 pytest-isort
 pytest-flake8
+pytest-mock
 responses
-mock
 safety

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,7 @@ def oauth_client(oauth_token):
         token=oauth_token,
         set_token=set_token,
     )
-    assert client.oauth.authorized is True
+    assert client._oauth_client.authorized is True
     return client
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -275,6 +275,17 @@ def test_client_request_timed_out(mocker, client):
         client.payments.list()
 
 
+def test_client_will_propagate_retry_setting(response):
+    response.get('https://api.mollie.com/v2/methods', 'methods_list')
+
+    client = Client(retry=3)
+    client.set_api_key("test_test")
+    client.methods.list()
+
+    adapter = client._client.adapters['https://']
+    assert adapter.max_retries.connect == 3
+
+
 def test_client_data_consistency_error(client, response):
     """When the API sends us data we did not expect raise an consistency error."""
     order_id = 'ord_kEn1PlbGa'


### PR DESCRIPTION
Solution for #178 

I opted for configuring the builtin retry mechanism of `urllib3` in stead of building our own version. This might not be as flexible as the PHP version, but it should function just as well, and of course the code is better tested than any custom-built feature.