### PR TITLE
Fix invalid get subscription payments endpoint url

### DIFF
--- a/mollie/api/resources/subscription_payments.py
+++ b/mollie/api/resources/subscription_payments.py
@@ -6,7 +6,7 @@ class SubscriptionPayments(Payments):
     subscription_id = None
 
     def get_resource_name(self):
-        return 'customers/{customer_id}/subscription/{subscription_id}/payments'.format(
+        return 'customers/{customer_id}/subscriptions/{subscription_id}/payments'.format(
             customer_id=self.customer_id,
             subscription_id=self.subscription_id,
         )

--- a/tests/test_customer_subscriptions.py
+++ b/tests/test_customer_subscriptions.py
@@ -138,7 +138,7 @@ def test_customer_subscription_get_related_payments(client, response):
     response.get('https://api.mollie.com/v2/customers/%s/subscriptions/%s' % (CUSTOMER_ID, SUBSCRIPTION_ID),
                  'subscription_single')
     response.get('https://api.mollie.com/v2/customers/%s' % CUSTOMER_ID, 'customer_single')
-    response.get('https://api.mollie.com/v2/customers/%s/subscription/%s/payments' % (CUSTOMER_ID, SUBSCRIPTION_ID),
+    response.get('https://api.mollie.com/v2/customers/%s/subscriptions/%s/payments' % (CUSTOMER_ID, SUBSCRIPTION_ID),
                  'payments_list')
     subscription = client.customer_subscriptions.with_parent_id(CUSTOMER_ID).get(SUBSCRIPTION_ID)
     payments = subscription.payments


### PR DESCRIPTION
See the docs: https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments

This should fix issue #190.