### PR TITLE
Set default number of retry attempts to three.

### DIFF
--- a/mollie/api/client.py
+++ b/mollie/api/client.py
@@ -72,7 +72,7 @@ class Client(object):
                     access_token=access_token))
         return access_token
 
-    def __init__(self, api_endpoint=None, timeout=(2, 10), retry=None):
+    def __init__(self, api_endpoint=None, timeout=(2, 10), retry=3):
         """Initialize a new Mollie API client.
 
         :param api_endpoint: The API endpoint to communicate to, this default to the production environment (string)


### PR DESCRIPTION
Mollie wants to use a retry policy that is enabled by default.

Based on a discussion on Slack with @rares-mollie 