### PR TITLE
Allow easy access to order payments through the order object.

### DIFF
--- a/mollie/api/error.py
+++ b/mollie/api/error.py
@@ -90,6 +90,22 @@ class DataConsistencyError(Error):
     pass
 
 
+class EmbedNotFound(Error):
+    """We could not access requested data with an object because the required embed was missing.
+
+    Some data within an object is only available after it is explicitly requested using an embed query parameter.
+    You tried to access data which is available from an embed, but the data is missing: apparently you forgot
+    to set the related embed parameter.
+    """
+
+    def __init__(self, embed_name):
+        msg = (
+            "You tried to access embedded data, but did not request to embed this data in the request. "
+            f'Please specify embed="{embed_name}" when requesting the data.'
+        )
+        super().__init__(msg)
+
+
 """
 Deprecation policy
 

--- a/mollie/api/objects/order.py
+++ b/mollie/api/objects/order.py
@@ -10,6 +10,17 @@ from .payment import Payment
 
 
 class Order(Base):
+    requested_embeds = None
+
+    def __init__(self, data, client=None, requested_embeds=None):
+        super().__init__(data, client)
+        self.requested_embeds = requested_embeds
+
+    def _has_embed(self, embed_name):
+        if self.requested_embeds and embed_name in self.requested_embeds:
+            return True
+        return False
+
     @classmethod
     def get_resource_class(cls, client):
         from ..resources.orders import Orders
@@ -214,10 +225,14 @@ class Order(Base):
 
     @property
     def payments(self):
+        if not self._has_embed("payments"):
+            raise EmbedNotFound("payments")
+
         try:
             payments = self["_embedded"]["payments"]
         except KeyError:
-            raise EmbedNotFound("payments")
+            # No data available at API
+            payments = []
 
         result = {
             "_embedded": {

--- a/mollie/api/objects/order.py
+++ b/mollie/api/objects/order.py
@@ -1,3 +1,4 @@
+from ..error import EmbedNotFound
 from ..resources.order_lines import OrderLines
 from ..resources.order_payments import OrderPayments
 from ..resources.order_refunds import OrderRefunds
@@ -5,6 +6,7 @@ from ..resources.shipments import Shipments
 from .base import Base
 from .list import List
 from .order_line import OrderLine
+from .payment import Payment
 
 
 class Order(Base):
@@ -209,6 +211,21 @@ class Order(Base):
     def update_shipment(self, resource_id, data):
         """Update the tracking information of a shipment."""
         return Shipments(self.client).on(self).update(resource_id, data)
+
+    @property
+    def payments(self):
+        try:
+            payments = self["_embedded"]["payments"]
+        except KeyError:
+            raise EmbedNotFound("payments")
+
+        result = {
+            "_embedded": {
+                "payments": payments,
+            },
+            "count": len(payments),
+        }
+        return List(result, Payment, self.client)
 
     def create_payment(self, data):
         """Creates a new payment object for an order."""

--- a/mollie/api/resources/base.py
+++ b/mollie/api/resources/base.py
@@ -66,3 +66,10 @@ class Base(object):
                     "(status code: {status}): '{response}'.".format(status=resp.status_code, response=resp.text)
                 )
         return result
+
+    @staticmethod
+    def extract_embed(params):
+        """Extract and parse the embed parameter from the request."""
+        if "embed" not in params:
+            return
+        return params["embed"].split(",")

--- a/mollie/api/resources/orders.py
+++ b/mollie/api/resources/orders.py
@@ -16,7 +16,14 @@ class Orders(Base):
                     id=order_id, prefix=self.RESOURCE_ID_PREFIX
                 )
             )
-        return super().get(order_id, **params)
+
+        result_order = super().get(order_id, **params)
+
+        requested_embeds = self.extract_embed(params)
+        if requested_embeds:
+            result_order.requested_embeds = requested_embeds
+
+        return result_order
 
     def delete(self, order_id, data=None):
         """Cancel order and return the order object.

--- a/tests/responses/order_single_with_embeds.json
+++ b/tests/responses/order_single_with_embeds.json
@@ -1,0 +1,285 @@
+{
+     "resource": "order",
+     "id": "ord_kEn1PlbGa",
+     "profileId": "pfl_URR55HPMGx",
+     "method": "ideal",
+     "amount": {
+         "value": "1027.99",
+         "currency": "EUR"
+     },
+     "status": "created",
+     "isCancelable": true,
+     "metadata": null,
+     "createdAt": "2018-08-02T09:29:56+00:00",
+     "expiresAt": "2018-08-30T09:29:56+00:00",
+     "mode": "live",
+     "locale": "nl_NL",
+     "billingAddress": {
+         "organizationName": "Mollie B.V.",
+         "streetAndNumber": "Keizersgracht 126",
+         "postalCode": "1015 CW",
+         "city": "Amsterdam",
+         "country": "nl",
+         "givenName": "Luke",
+         "familyName": "Skywalker",
+         "email": "luke@skywalker.com"
+     },
+     "shopperCountryMustMatchBillingCountry": false,
+     "consumerDateOfBirth": "1993-10-21",
+     "orderNumber": "18475",
+     "shippingAddress": {
+         "organizationName": "Mollie B.V.",
+         "streetAndNumber": "Keizersgracht 126",
+         "postalCode": "1015 CW",
+         "city": "Amsterdam",
+         "country": "nl",
+         "givenName": "Luke",
+         "familyName": "Skywalker",
+         "email": "luke@skywalker.com"
+     },
+     "redirectUrl": "https://example.org/redirect",
+     "lines": [
+         {
+             "resource": "orderline",
+             "id": "odl_dgtxyl",
+             "orderId": "ord_pbjz8x",
+             "name": "LEGO 42083 Bugatti Chiron",
+             "sku": "5702016116977",
+             "type": "physical",
+             "status": "created",
+             "metadata": null,
+             "isCancelable": false,
+             "quantity": 2,
+             "quantityShipped": 0,
+             "amountShipped": {
+                 "value": "0.00",
+                 "currency": "EUR"
+             },
+             "quantityRefunded": 0,
+             "amountRefunded": {
+                 "value": "0.00",
+                 "currency": "EUR"
+             },
+             "quantityCanceled": 0,
+             "amountCanceled": {
+                 "value": "0.00",
+                 "currency": "EUR"
+             },
+             "shippableQuantity": 0,
+             "refundableQuantity": 0,
+             "cancelableQuantity": 0,
+             "unitPrice": {
+                 "value": "399.00",
+                 "currency": "EUR"
+             },
+             "vatRate": "21.00",
+             "vatAmount": {
+                 "value": "121.14",
+                 "currency": "EUR"
+             },
+             "discountAmount": {
+                 "value": "100.00",
+                 "currency": "EUR"
+             },
+             "totalAmount": {
+                 "value": "698.00",
+                 "currency": "EUR"
+             },
+             "createdAt": "2018-08-02T09:29:56+00:00",
+             "_links": {
+                 "productUrl": {
+                     "href": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
+                     "type": "text/html"
+                 },
+                 "imageUrl": {
+                     "href": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
+                     "type": "text/html"
+                 }
+             }
+         },
+         {
+             "resource": "orderline",
+             "id": "odl_jp31jz",
+             "orderId": "ord_pbjz8x",
+             "name": "LEGO 42056 Porsche 911 GT3 RS",
+             "sku": "5702015594028",
+             "type": "physical",
+             "status": "created",
+             "metadata": null,
+             "isCancelable": false,
+             "quantity": 1,
+             "quantityShipped": 0,
+             "amountShipped": {
+                 "value": "0.00",
+                 "currency": "EUR"
+             },
+             "quantityRefunded": 0,
+             "amountRefunded": {
+                 "value": "0.00",
+                 "currency": "EUR"
+             },
+             "quantityCanceled": 0,
+             "amountCanceled": {
+                 "value": "0.00",
+                 "currency": "EUR"
+             },
+             "shippableQuantity": 0,
+             "refundableQuantity": 0,
+             "cancelableQuantity": 0,
+             "unitPrice": {
+                 "value": "329.99",
+                 "currency": "EUR"
+             },
+             "vatRate": "21.00",
+             "vatAmount": {
+                 "value": "57.27",
+                 "currency": "EUR"
+             },
+             "totalAmount": {
+                 "value": "329.99",
+                 "currency": "EUR"
+             },
+             "createdAt": "2018-08-02T09:29:56+00:00",
+             "_links": {
+                 "productUrl": {
+                     "href": "https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056",
+                     "type": "text/html"
+                 },
+                 "imageUrl": {
+                     "href": "https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$",
+                     "type": "text/html"
+                 }
+             }
+         }
+     ],
+     "_embedded": {
+         "payments": [
+             {
+                 "resource": "payment",
+                 "id": "tr_ncaPcAhuUV",
+                 "mode": "live",
+                 "createdAt": "2018-09-07T12:00:05+00:00",
+                 "amount": {
+                     "value": "1027.99",
+                     "currency": "EUR"
+                 },
+                 "description": "Order #1337 (Lego cars)",
+                 "method": null,
+                 "metadata": null,
+                 "status": "open",
+                 "isCancelable": false,
+                 "locale": "nl_NL",
+                 "profileId": "pfl_URR55HPMGx",
+                 "orderId": "ord_kEn1PlbGa",
+                 "sequenceType": "oneoff",
+                 "redirectUrl": "https://example.org/redirect",
+                 "_links": {
+                     "self": {
+                         "href": "https://api.mollie.com/v2/payments/tr_ncaPcAhuUV",
+                         "type": "application/hal+json"
+                     },
+                     "checkout": {
+                         "href": "https://www.mollie.com/payscreen/select-method/ncaPcAhuUV",
+                         "type": "text/html"
+                     },
+                     "dashboard": {
+                         "href": "https://www.mollie.com/dashboard/org_123456789/payments/tr_ncaPcAhuUV",
+                         "type": "text/html"
+                     },
+                     "order": {
+                         "href": "https://api.mollie.com/v2/orders/ord_kEn1PlbGa",
+                         "type": "application/hal+json"
+                     }
+                 }
+             }
+         ],
+         "refunds": [
+             {
+                 "resource": "refund",
+                 "id": "re_vD3Jm32wQt",
+                 "amount": {
+                     "value": "329.99",
+                     "currency": "EUR"
+                 },
+                 "status": "pending",
+                 "createdAt": "2019-01-15T15:41:21+00:00",
+                 "description": "Required quantity not in stock, refunding one photo book.",
+                 "orderId": "ord_kEn1PlbGa",
+                 "paymentId": "tr_mjvPwykz3x",
+                 "settlementAmount": {
+                     "value": "-329.99",
+                     "currency": "EUR"
+                 },
+                 "lines": [
+                     {
+                         "resource": "orderline",
+                         "id": "odl_dgtxyl",
+                         "orderId": "ord_kEn1PlbGa",
+                         "name": "LEGO 42056 Porsche 911 GT3 RS",
+                         "sku": "5702015594028",
+                         "type": "physical",
+                         "status": "completed",
+                         "isCancelable": false,
+                         "quantity": 1,
+                         "unitPrice": {
+                             "value": "329.99",
+                             "currency": "EUR"
+                         },
+                         "vatRate": "21.00",
+                         "vatAmount": {
+                             "value": "57.27",
+                             "currency": "EUR"
+                         },
+                         "totalAmount": {
+                             "value": "329.99",
+                             "currency": "EUR"
+                         },
+                         "createdAt": "2019-01-15T15:22:45+00:00",
+                         "_links": {
+                             "productUrl": {
+                                 "href": "https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056",
+                                 "type": "text/html"
+                             },
+                             "imageUrl": {
+                                 "href": "https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$",
+                                 "type": "text/html"
+                             }
+                         }
+                     }
+                 ],
+                 "_links": {
+                     "self": {
+                         "href": "https://api.mollie.com/v2/payments/tr_mjvPwykz3x/refunds/re_vD3Jm32wQt",
+                         "type": "application/hal+json"
+                     },
+                     "payment": {
+                         "href": "https://api.mollie.com/v2/payments/tr_mjvPwykz3x",
+                         "type": "application/hal+json"
+                     },
+                     "order": {
+                         "href": "https://api.mollie.com/v2/orders/ord_kEn1PlbGa",
+                         "type": "application/hal+json"
+                     }
+                 }
+             }
+         ]
+     },
+     "_links": {
+         "self": {
+             "href": "https://api.mollie.com/v2/orders/ord_pbjz8x",
+             "type": "application/hal+json"
+         },
+         "checkout": {
+             "href": "https://www.mollie.com/payscreen/order/checkout/pbjz8x",
+             "type": "text/html"
+         },
+        "dashboard": {
+            "href": "https://www.mollie.com/dashboard/org_123456789/orders/ord_pbjz8x",
+            "type": "text/html"
+        },
+         "documentation": {
+             "href": "https://docs.mollie.com/reference/v2/orders-api/get-order",
+             "type": "text/html"
+         }
+     }
+ }

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,3 +1,6 @@
+import pytest
+
+from mollie.api.error import EmbedNotFound
 from mollie.api.objects.order import Order
 from mollie.api.objects.payment import Payment
 from mollie.api.objects.refund import Refund
@@ -73,6 +76,30 @@ def test_get_order(client, response):
     assert order.is_shipping() is False
     assert order.is_completed() is False
     assert order.is_expired() is False
+
+    with pytest.raises(EmbedNotFound):
+        order.payments
+
+
+def test_get_order_with_payments(client, response):
+    response.add(
+        response.GET,
+        f"https://api.mollie.com/v2/orders/{ORDER_ID}?embed=payments",
+        body=response._get_body("order_single_with_embeds"),
+        match_querystring=True,
+    )
+
+    order = client.orders.get(ORDER_ID, embed="payments")
+    assert_list_object(order.payments, Payment)
+
+
+def test_get_order_with_payments_embed_error(client, response):
+    response.get(f"https://api.mollie.com/v2/orders/{ORDER_ID}", "order_single")
+
+    order = client.orders.get(ORDER_ID)
+    with pytest.raises(EmbedNotFound) as excinfo:
+        order.payments
+    assert 'Please specify embed="payments" when requesting the data.' in str(excinfo.value)
 
 
 def test_list_orders(client, response):

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -69,7 +69,6 @@ def test_get_order(client, response):
     assert order.checkout_url == "https://www.mollie.com/payscreen/order/checkout/kEn1PlbGa"
     assert_list_object(order.shipments, Shipment)
     assert_list_object(order.refunds, Refund)
-
     assert order.is_created() is True
     assert order.is_paid() is False
     assert order.is_authorized() is False
@@ -100,6 +99,18 @@ def test_get_order_with_payments_embed_error(client, response):
     with pytest.raises(EmbedNotFound) as excinfo:
         order.payments
     assert 'Please specify embed="payments" when requesting the data.' in str(excinfo.value)
+
+
+def test_get_order_with_payments_empty_embed(client, response):
+    response.add(
+        response.GET,
+        f"https://api.mollie.com/v2/orders/{ORDER_ID}?embed=payments",
+        body=response._get_body("order_single"),
+        match_querystring=True,
+    )
+
+    order = client.orders.get(ORDER_ID, embed="payments")
+    assert_list_object(order.payments, Payment, 0)
 
 
 def test_list_orders(client, response):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,11 +1,14 @@
 from mollie.api.objects.list import List
 
 
-def assert_list_object(obj, object_type):
+def assert_list_object(obj, object_type, count=None):
     """Assert that a List object is correctly working, and has sane contents."""
     assert isinstance(obj, List), "Object {obj} is not a List instance.".format(obj=obj)
     assert isinstance(obj.count, int), "List count is not an integer."
-    assert obj.count > 0
+    if count is not None:
+        assert obj.count == count, "List does not contain the expected number of items."
+    else:
+        assert obj.count > 0, "List has no items."
 
     # verify items in list
     items = []


### PR DESCRIPTION
There is no easy way to access the payments related to an order, other than using the embedded data. We have no support for accessing embedded data up to now. 

This PR helps a customer that wants to access all payments related to an order, and serves as a proposal on how to access embedded data. In the future, we can apply this method to other embedded datasets as well, thereby giving access to more data  and lowering API calls.