### PR TITLE
Remove string interpolation using percentage sign.

### DIFF
--- a/mollie/api/client.py
+++ b/mollie/api/client.py
@@ -171,10 +171,10 @@ class Client(object):
         return " ".join(components)
 
     def _format_request_data(self, path, data, params):
-        if path.startswith("%s/%s" % (self.api_endpoint, self.api_version)):
+        if path.startswith(f"{self.api_endpoint}/{self.api_version}"):
             url = path
         else:
-            url = "%s/%s/%s" % (self.api_endpoint, self.api_version, path)
+            url = f"{self.api_endpoint}/{self.api_version}/{path}"
 
         if data is not None:
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def oauth_client(oauth_token):
     scope = ("organizations.read",)
 
     def set_token(x):
-        logger.info("Storing token: %s", x)
+        logger.info(f"Storing token: {x}")
 
     client = Client()
     client.setup_oauth(
@@ -85,7 +85,7 @@ class ImprovedRequestsMock(responses.RequestsMock):
 
     def _get_body(self, filename):
         """Read the response fixture file and return it."""
-        file = os.path.join(os.path.dirname(__file__), "responses", "%s.json" % filename)
+        file = os.path.join(os.path.dirname(__file__), "responses", f"{filename}.json")
         return open(file).read()
 
 

--- a/tests/test_customer_mandates.py
+++ b/tests/test_customer_mandates.py
@@ -9,7 +9,7 @@ MANDATE_ID = "mdt_h3gAaD5zP"
 
 def test_list_customer_mandates(client, response):
     """Retrieve a list of mandates."""
-    response.get("https://api.mollie.com/v2/customers/%s/mandates" % CUSTOMER_ID, "customer_mandates_list")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/mandates", "customer_mandates_list")
     mandates = client.customer_mandates.with_parent_id(CUSTOMER_ID).list()
     assert_list_object(mandates, Mandate)
 
@@ -17,10 +17,10 @@ def test_list_customer_mandates(client, response):
 def test_get_customer_mandate_by_id(client, response):
     """Retrieve a single mandate by ID."""
     response.get(
-        "https://api.mollie.com/v2/customers/%s/mandates/%s" % (CUSTOMER_ID, MANDATE_ID),
+        f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/mandates/{MANDATE_ID}",
         "customer_mandate_single",
     )
-    response.get("https://api.mollie.com/v2/customers/%s" % CUSTOMER_ID, "customer_new")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}", "customer_new")
 
     mandate = client.customer_mandates.with_parent_id(CUSTOMER_ID).get(MANDATE_ID)
     assert isinstance(mandate, Mandate)
@@ -44,10 +44,10 @@ def test_get_customer_mandate_by_id(client, response):
 
 def test_get_customer_mandate_by_customer(client, response):
     """Retrieve a customer by customer object."""
-    response.get("https://api.mollie.com/v2/customers/%s" % CUSTOMER_ID, "customer_new")
-    response.get("https://api.mollie.com/v2/customers/%s/mandates" % CUSTOMER_ID, "customer_mandates_list")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}", "customer_new")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/mandates", "customer_mandates_list")
     response.get(
-        "https://api.mollie.com/v2/customers/%s/mandates/%s" % (CUSTOMER_ID, MANDATE_ID),
+        f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/mandates/{MANDATE_ID}",
         "customer_mandate_single",
     )
     customer = client.customers.get(CUSTOMER_ID)
@@ -63,10 +63,10 @@ def test_get_customer_mandate_by_customer(client, response):
 def test_customer_mandate_get_related_customer(client, response):
     """Retrieve a related customer object from a mandate."""
     response.get(
-        "https://api.mollie.com/v2/customers/%s/mandates/%s" % (CUSTOMER_ID, MANDATE_ID),
+        f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/mandates/{MANDATE_ID}",
         "customer_mandate_single",
     )
-    response.get("https://api.mollie.com/v2/customers/%s" % CUSTOMER_ID, "customer_new")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}", "customer_new")
 
     mandate = client.customer_mandates.with_parent_id(CUSTOMER_ID).get(MANDATE_ID)
     assert isinstance(mandate.customer, Customer)
@@ -75,7 +75,7 @@ def test_customer_mandate_get_related_customer(client, response):
 
 def test_customer_mandates_create_mandate(client, response):
     """Create a new customer mandate."""
-    response.post("https://api.mollie.com/v2/customers/%s/mandates" % CUSTOMER_ID, "customer_mandate_single")
+    response.post(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/mandates", "customer_mandate_single")
 
     data = {
         "method": "directdebit",
@@ -92,7 +92,7 @@ def test_customer_mandates_create_mandate(client, response):
 
 def test_update_customer_mandate(client, response):
     response.patch(
-        "https://api.mollie.com/v2/customers/%s/mandates/%s" % (CUSTOMER_ID, MANDATE_ID), "customer_mandate_updated"
+        f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/mandates/{MANDATE_ID}", "customer_mandate_updated"
     )
 
     data = {
@@ -109,7 +109,11 @@ def test_update_customer_mandate(client, response):
 
 
 def test_revoke_customer_mandate(client, response):
-    response.delete("https://api.mollie.com/v2/customers/%s/mandates/%s" % (CUSTOMER_ID, MANDATE_ID), "empty", 204)
+    response.delete(
+        f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/mandates/{MANDATE_ID}",
+        "empty",
+        204,
+    )
 
     resp = client.customer_mandates.with_parent_id(CUSTOMER_ID).delete(MANDATE_ID)
     assert resp == {}

--- a/tests/test_customer_payments.py
+++ b/tests/test_customer_payments.py
@@ -7,15 +7,15 @@ CUSTOMER_ID = "cst_8wmqcHMN4U"
 
 def test_list_customer_payments(client, response):
     """Retrieve a list of payments related to a customer id."""
-    response.get("https://api.mollie.com/v2/customers/%s/payments" % CUSTOMER_ID, "customer_payments_multiple")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/payments", "customer_payments_multiple")
 
     payments = client.customer_payments.with_parent_id(CUSTOMER_ID).list()
     assert_list_object(payments, Payment)
 
 
 def test_list_customer_payments_by_object(client, response):
-    response.get("https://api.mollie.com/v2/customers/%s" % CUSTOMER_ID, "customer_single")
-    response.get("https://api.mollie.com/v2/customers/%s/payments" % CUSTOMER_ID, "customer_payments_multiple")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}", "customer_single")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/payments", "customer_payments_multiple")
 
     customer = client.customers.get(CUSTOMER_ID)
     payments = client.customer_payments.on(customer).list()
@@ -24,7 +24,7 @@ def test_list_customer_payments_by_object(client, response):
 
 def test_create_customer_payment(client, response):
     """Create a customer payment."""
-    response.post("https://api.mollie.com/v2/customers/%s/payments" % CUSTOMER_ID, "payment_single")
+    response.post(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/payments", "payment_single")
 
     payment = client.customer_payments.with_parent_id(CUSTOMER_ID).create(
         {

--- a/tests/test_customer_subscriptions.py
+++ b/tests/test_customer_subscriptions.py
@@ -14,7 +14,7 @@ SUBSCRIPTION_ID = "sub_rVKGtNd6s3"
 
 def test_list_customer_subscriptions(client, response):
     """Retrieve a list of subscriptions."""
-    response.get("https://api.mollie.com/v2/customers/%s/subscriptions" % CUSTOMER_ID, "subscriptions_customer_list")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/subscriptions", "subscriptions_customer_list")
 
     subscriptions = client.customer_subscriptions.with_parent_id(CUSTOMER_ID).list()
     assert_list_object(subscriptions, Subscription)
@@ -23,10 +23,10 @@ def test_list_customer_subscriptions(client, response):
 def test_get_customer_subscription_by_id(client, response):
     """Retrieve a single subscription by ID."""
     response.get(
-        "https://api.mollie.com/v2/customers/%s/subscriptions/%s" % (CUSTOMER_ID, SUBSCRIPTION_ID),
+        f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/subscriptions/{SUBSCRIPTION_ID}",
         "subscription_single",
     )
-    response.get("https://api.mollie.com/v2/customers/%s" % CUSTOMER_ID, "customer_single")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}", "customer_single")
 
     subscription = client.customer_subscriptions.with_parent_id(CUSTOMER_ID).get(SUBSCRIPTION_ID)
     assert subscription.resource == "subscription"
@@ -53,8 +53,8 @@ def test_get_customer_subscription_by_id(client, response):
 
 def test_list_customer_subscriptions_by_customer_object(client, response):
     """Retrieve a list of subscriptions related to customer."""
-    response.get("https://api.mollie.com/v2/customers/%s" % CUSTOMER_ID, "customer_single")
-    response.get("https://api.mollie.com/v2/customers/%s/subscriptions" % CUSTOMER_ID, "subscriptions_customer_list")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}", "customer_single")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/subscriptions", "subscriptions_customer_list")
 
     customer = client.customers.get(CUSTOMER_ID)
     subscriptions = client.customer_subscriptions.on(customer).list()
@@ -64,10 +64,10 @@ def test_list_customer_subscriptions_by_customer_object(client, response):
 def test_get_customer_subscription_by_customer_object(client, response):
     """Retrieve specific subscription related to customer."""
     response.get(
-        "https://api.mollie.com/v2/customers/%s/subscriptions/%s" % (CUSTOMER_ID, SUBSCRIPTION_ID),
+        f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/subscriptions/{SUBSCRIPTION_ID}",
         "subscription_single",
     )
-    response.get("https://api.mollie.com/v2/customers/%s" % CUSTOMER_ID, "customer_single")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}", "customer_single")
 
     customer = client.customers.get(CUSTOMER_ID)
     subscription = client.customer_subscriptions.on(customer).get(SUBSCRIPTION_ID)
@@ -78,10 +78,10 @@ def test_get_customer_subscription_by_customer_object(client, response):
 def test_customer_subscription_get_related_customer(client, response):
     """Retrieve a related customer object from a subscription."""
     response.get(
-        "https://api.mollie.com/v2/customers/%s/subscriptions/%s" % (CUSTOMER_ID, SUBSCRIPTION_ID),
+        f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/subscriptions/{SUBSCRIPTION_ID}",
         "subscription_single",
     )
-    response.get("https://api.mollie.com/v2/customers/%s" % CUSTOMER_ID, "customer_single")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}", "customer_single")
 
     subscription = client.customer_subscriptions.with_parent_id(CUSTOMER_ID).get(SUBSCRIPTION_ID)
     assert isinstance(subscription.customer, Customer)
@@ -91,7 +91,7 @@ def test_customer_subscription_get_related_customer(client, response):
 def test_cancel_customer_subscription(client, response):
     """Cancel a subscription by customer ID and subscription ID."""
     response.delete(
-        "https://api.mollie.com/v2/customers/%s/subscriptions/%s" % (CUSTOMER_ID, SUBSCRIPTION_ID),
+        f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/subscriptions/{SUBSCRIPTION_ID}",
         "subscription_canceled",
         200,
     )
@@ -110,7 +110,7 @@ def test_cancel_customer_subscription_invalid_id(client):
 
 def test_create_customer_subscription(client, response):
     """Create a subscription with customer object."""
-    response.post("https://api.mollie.com/v2/customers/%s/subscriptions" % CUSTOMER_ID, "subscription_single")
+    response.post(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/subscriptions", "subscription_single")
 
     data = {
         "amount": {"currency": "EUR", "value": "25.00"},
@@ -127,7 +127,7 @@ def test_create_customer_subscription(client, response):
 def test_update_customer_subscription(client, response):
     """Update existing subscription of a customer."""
     response.patch(
-        "https://api.mollie.com/v2/customers/%s/subscriptions/%s" % (CUSTOMER_ID, SUBSCRIPTION_ID),
+        f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/subscriptions/{SUBSCRIPTION_ID}",
         "subscription_updated",
     )
 
@@ -146,12 +146,12 @@ def test_update_customer_subscription(client, response):
 def test_customer_subscription_get_related_payments(client, response):
     """Retrieve a list of payments related to the subscription."""
     response.get(
-        "https://api.mollie.com/v2/customers/%s/subscriptions/%s" % (CUSTOMER_ID, SUBSCRIPTION_ID),
+        f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/subscriptions/{SUBSCRIPTION_ID}",
         "subscription_single",
     )
-    response.get("https://api.mollie.com/v2/customers/%s" % CUSTOMER_ID, "customer_single")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}", "customer_single")
     response.get(
-        "https://api.mollie.com/v2/customers/%s/subscriptions/%s/payments" % (CUSTOMER_ID, SUBSCRIPTION_ID),
+        f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/subscriptions/{SUBSCRIPTION_ID}/payments",
         "payments_list",
     )
     subscription = client.customer_subscriptions.with_parent_id(CUSTOMER_ID).get(SUBSCRIPTION_ID)

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -25,7 +25,7 @@ def test_create_customer(client, response):
 
 def test_update_customer(client, response):
     """Update an existing customer."""
-    response.patch("https://api.mollie.com/v2/customers/%s" % CUSTOMER_ID, "customer_updated")
+    response.patch(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}", "customer_updated")
 
     updated_customer = client.customers.update(
         CUSTOMER_ID,
@@ -41,7 +41,7 @@ def test_update_customer(client, response):
 
 def test_delete_customer(client, response):
     """Delete a customer."""
-    response.delete("https://api.mollie.com/v2/customers/%s" % CUSTOMER_ID, "empty")
+    response.delete(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}", "empty")
 
     deleted_customer = client.customers.delete("cst_8wmqcHMN4U")
     assert deleted_customer == {}
@@ -57,10 +57,10 @@ def test_list_customers(client, response):
 
 def test_get_customer(client, response):
     """Retrieve a single customer."""
-    response.get("https://api.mollie.com/v2/customers/%s" % CUSTOMER_ID, "customer_new")
-    response.get("https://api.mollie.com/v2/customers/%s/subscriptions" % CUSTOMER_ID, "subscriptions_customer_list")
-    response.get("https://api.mollie.com/v2/customers/%s/mandates" % CUSTOMER_ID, "customer_mandates_list")
-    response.get("https://api.mollie.com/v2/customers/%s/payments" % CUSTOMER_ID, "customer_payments_multiple")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}", "customer_new")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/subscriptions", "subscriptions_customer_list")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/mandates", "customer_mandates_list")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/payments", "customer_payments_multiple")
 
     customer = client.customers.get(CUSTOMER_ID)
     assert isinstance(customer, Customer)
@@ -79,8 +79,8 @@ def test_get_customer(client, response):
 
 def test_customer_get_related_mandates(client, response):
     """Retrieve related mandates for a customer."""
-    response.get("https://api.mollie.com/v2/customers/%s" % CUSTOMER_ID, "customer_updated")
-    response.get("https://api.mollie.com/v2/customers/%s/mandates" % CUSTOMER_ID, "customer_mandates_list")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}", "customer_updated")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/mandates", "customer_mandates_list")
 
     customer = client.customers.get(CUSTOMER_ID)
     mandates = customer.mandates
@@ -89,8 +89,8 @@ def test_customer_get_related_mandates(client, response):
 
 def test_customer_get_related_subscriptions(client, response):
     """Retrieve related subscriptions for a customer."""
-    response.get("https://api.mollie.com/v2/customers/%s" % CUSTOMER_ID, "customer_single")
-    response.get("https://api.mollie.com/v2/customers/%s/subscriptions" % CUSTOMER_ID, "subscriptions_customer_list")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}", "customer_single")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/subscriptions", "subscriptions_customer_list")
 
     customer = client.customers.get(CUSTOMER_ID)
     subscriptions = customer.subscriptions
@@ -99,8 +99,8 @@ def test_customer_get_related_subscriptions(client, response):
 
 def test_customer_get_related_payments(client, response):
     """Retrieve related payments for a customer."""
-    response.get("https://api.mollie.com/v2/customers/%s" % CUSTOMER_ID, "customer_new")
-    response.get("https://api.mollie.com/v2/customers/%s/payments" % CUSTOMER_ID, "customer_payments_multiple")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}", "customer_new")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}/payments", "customer_payments_multiple")
 
     customer = client.customers.get(CUSTOMER_ID)
     payments = customer.payments

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -15,7 +15,7 @@ def test_list_invoices(oauth_client, response):
 
 def test_get_invoice(oauth_client, response):
     """Retrieve a single invoice."""
-    response.get("https://api.mollie.com/v2/invoices/%s" % INVOICE_ID, "invoice_single")
+    response.get(f"https://api.mollie.com/v2/invoices/{INVOICE_ID}", "invoice_single")
 
     invoice = oauth_client.invoices.get(INVOICE_ID)
     assert isinstance(invoice, Invoice)

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -35,7 +35,7 @@ def test_create_onboarding(oauth_client, response):
 def test_onboarding_get_organization(oauth_client, response):
     """Retrieve organization related to onboarding."""
     response.get("https://api.mollie.com/v2/onboarding/me", "onboarding_me")
-    response.get("https://api.mollie.com/v2/organization/%s" % ORGANIZATION_ID, "organization_single")
+    response.get(f"https://api.mollie.com/v2/organization/{ORGANIZATION_ID}", "organization_single")
 
     onboarding = oauth_client.onboarding.get("me")
     organization = onboarding.organization

--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -5,7 +5,7 @@ ORGANIZATION_ID = "org_12345678"
 
 def test_get_organization(oauth_client, response):
     """Retrieve a single organization."""
-    response.get("https://api.mollie.com/v2/organizations/%s" % ORGANIZATION_ID, "organization_single")
+    response.get(f"https://api.mollie.com/v2/organizations/{ORGANIZATION_ID}", "organization_single")
 
     organization = oauth_client.organizations.get(ORGANIZATION_ID)
     assert isinstance(organization, Organization)

--- a/tests/test_payment_captures.py
+++ b/tests/test_payment_captures.py
@@ -11,14 +11,14 @@ SHIPMENT_ID = "shp_3wmsgCJN4U"
 
 
 def test_capture_resource_class(client, response):
-    response.get("https://api.mollie.com/v2/payments/%s/captures/%s" % (PAYMENT_ID, CAPTURE_ID), "capture_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/captures/{CAPTURE_ID}", "capture_single")
     client.captures.with_parent_id(PAYMENT_ID).get(CAPTURE_ID)
     assert isinstance(Capture.get_resource_class(client), Captures)
 
 
 def test_get_payment_captures_by_payment_id(client, response):
     """Get capture relevant to payment by payment id."""
-    response.get("https://api.mollie.com/v2/payments/%s/captures" % PAYMENT_ID, "captures_list")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/captures", "captures_list")
 
     captures = client.captures.with_parent_id(PAYMENT_ID).list()
     assert_list_object(captures, Capture)
@@ -26,7 +26,7 @@ def test_get_payment_captures_by_payment_id(client, response):
 
 def test_get_single_payment_capture(client, response):
     """Get a single capture relevant to payment by payment id."""
-    response.get("https://api.mollie.com/v2/payments/%s/captures/%s" % (PAYMENT_ID, CAPTURE_ID), "capture_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/captures/{CAPTURE_ID}", "capture_single")
 
     capture = client.captures.with_parent_id(PAYMENT_ID).get(CAPTURE_ID)
     assert isinstance(capture, Capture)
@@ -42,8 +42,8 @@ def test_get_single_payment_capture(client, response):
 
 def test_list_payment_captures_by_payment_object(client, response):
     """Get a list of capture relevant to payment object."""
-    response.get("https://api.mollie.com/v2/payments/%s/captures" % PAYMENT_ID, "captures_list")
-    response.get("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/captures", "captures_list")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
     payment = client.payments.get(PAYMENT_ID)
     captures = client.captures.on(payment).list()
     assert_list_object(captures, Capture)
@@ -51,8 +51,8 @@ def test_list_payment_captures_by_payment_object(client, response):
 
 def test_get_single_payment_capture_by_payment_object(client, response):
     """Get a single capture relevant to payment object."""
-    response.get("https://api.mollie.com/v2/payments/%s/captures/%s" % (PAYMENT_ID, CAPTURE_ID), "capture_single")
-    response.get("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/captures/{CAPTURE_ID}", "capture_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
 
     payment = client.payments.get(PAYMENT_ID)
     capture = client.captures.on(payment).get(CAPTURE_ID)
@@ -62,9 +62,8 @@ def test_get_single_payment_capture_by_payment_object(client, response):
 
 def test_capture_get_related_payment(client, response):
     """Verify the related payment of a capture."""
-    #
-    response.get("https://api.mollie.com/v2/payments/%s/captures/%s" % (PAYMENT_ID, CAPTURE_ID), "capture_single")
-    response.get("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/captures/{CAPTURE_ID}", "capture_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
 
     capture = client.captures.with_parent_id(PAYMENT_ID).get(CAPTURE_ID)
     payment = capture.payment
@@ -75,7 +74,7 @@ def test_capture_get_related_payment(client, response):
 def test_capture_get_related_shipment(client, response):
     """Verify the related shipment of a capture."""
 
-    response.get("https://api.mollie.com/v2/payments/%s/captures/%s" % (PAYMENT_ID, CAPTURE_ID), "capture_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/captures/{CAPTURE_ID}", "capture_single")
     response.get("https://api.mollie.com/v2/orders/ord_8wmqcHMN4U/shipments/shp_3wmsgCJN4U", "shipment_single")
 
     capture = client.captures.with_parent_id(PAYMENT_ID).get(CAPTURE_ID)

--- a/tests/test_payment_chargebacks.py
+++ b/tests/test_payment_chargebacks.py
@@ -8,7 +8,7 @@ CHARGEBACK_ID = "chb_n9z0tp"
 
 def test_get_payment_chargebacks_by_payment_id(client, response):
     """Get chargebacks relevant to payment by payment id."""
-    response.get("https://api.mollie.com/v2/payments/%s/chargebacks" % PAYMENT_ID, "chargebacks_list")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/chargebacks", "chargebacks_list")
 
     chargebacks = client.payment_chargebacks.with_parent_id(PAYMENT_ID).list()
     assert_list_object(chargebacks, Chargeback)
@@ -16,9 +16,7 @@ def test_get_payment_chargebacks_by_payment_id(client, response):
 
 def test_get_single_payment_chargeback(client, response):
     """Get a single chargeback relevant to payment by payment id."""
-    response.get(
-        "https://api.mollie.com/v2/payments/%s/chargebacks/%s" % (PAYMENT_ID, CHARGEBACK_ID), "chargeback_single"
-    )
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/chargebacks/{CHARGEBACK_ID}", "chargeback_single")
 
     chargeback = client.payment_chargebacks.with_parent_id(PAYMENT_ID).get(CHARGEBACK_ID)
     assert isinstance(chargeback, Chargeback)
@@ -32,8 +30,8 @@ def test_get_single_payment_chargeback(client, response):
 
 def test_list_payment_chargebacks_by_payment_object(client, response):
     """Get a list of chargebacks relevant to payment object."""
-    response.get("https://api.mollie.com/v2/payments/%s/chargebacks" % PAYMENT_ID, "chargebacks_list")
-    response.get("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/chargebacks", "chargebacks_list")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
 
     payment = client.payments.get(PAYMENT_ID)
     chargebacks = client.payment_chargebacks.on(payment).list()
@@ -42,10 +40,8 @@ def test_list_payment_chargebacks_by_payment_object(client, response):
 
 def test_get_single_payment_chargeback_by_payment_object(client, response):
     """Get a single chargeback relevant to payment object."""
-    response.get(
-        "https://api.mollie.com/v2/payments/%s/chargebacks/%s" % (PAYMENT_ID, CHARGEBACK_ID), "chargeback_single"
-    )
-    response.get("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/chargebacks/{CHARGEBACK_ID}", "chargeback_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
 
     payment = client.payments.get(PAYMENT_ID)
     chargeback = client.payment_chargebacks.on(payment).get(CHARGEBACK_ID)

--- a/tests/test_payment_refunds.py
+++ b/tests/test_payment_refunds.py
@@ -12,8 +12,8 @@ ORDER_ID = "ord_kEn1PlbGa"
 
 def test_get_refund(client, response):
     """Retrieve a specific refund of a payment."""
-    response.get("https://api.mollie.com/v2/payments/%s/refunds/%s" % (PAYMENT_ID, REFUND_ID), "refund_single")
-    response.get("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/refunds/{REFUND_ID}", "refund_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
     response.get("https://api.mollie.com/v2/orders/{order_id}".format(order_id=ORDER_ID), "order_single")
 
     refund = client.payment_refunds.with_parent_id(PAYMENT_ID).get(REFUND_ID)
@@ -42,8 +42,8 @@ def test_get_refund(client, response):
 
 def test_refund_get_related_payment(client, response):
     """Verify the related payment of a refund."""
-    response.get("https://api.mollie.com/v2/payments/%s/refunds/%s" % (PAYMENT_ID, REFUND_ID), "refund_single")
-    response.get("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/refunds/{REFUND_ID}", "refund_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
 
     refund = client.payment_refunds.with_parent_id(PAYMENT_ID).get(REFUND_ID)
     payment = refund.payment
@@ -53,7 +53,7 @@ def test_refund_get_related_payment(client, response):
 
 def test_create_refund(client, response):
     """Create a payment refund of a payment."""
-    response.post("https://api.mollie.com/v2/payments/%s/refunds" % PAYMENT_ID, "refund_single")
+    response.post(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/refunds", "refund_single")
 
     data = {"amount": {"value": "5.95", "currency": "EUR"}}
     refund = client.payment_refunds.with_parent_id(PAYMENT_ID).create(data)
@@ -63,8 +63,8 @@ def test_create_refund(client, response):
 
 def test_get_single_refund_on_payment_object(client, response):
     """Retrieve a payment refund of a payment."""
-    response.get("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_single")
-    response.get("https://api.mollie.com/v2/payments/%s/refunds/%s" % (PAYMENT_ID, REFUND_ID), "refund_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/refunds/{REFUND_ID}", "refund_single")
 
     payment = client.payments.get(PAYMENT_ID)
     refund = client.payment_refunds.on(payment).get(REFUND_ID)
@@ -74,8 +74,8 @@ def test_get_single_refund_on_payment_object(client, response):
 
 def test_list_refunds_on_payment_object(client, response):
     """Retrieve a list of payment refunds of a payment."""
-    response.get("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_single")
-    response.get("https://api.mollie.com/v2/payments/%s/refunds" % PAYMENT_ID, "refunds_list")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/refunds", "refunds_list")
 
     payment = client.payments.get(PAYMENT_ID)
     refunds = client.payment_refunds.on(payment).list()
@@ -84,7 +84,7 @@ def test_list_refunds_on_payment_object(client, response):
 
 def test_cancel_refund(client, response):
     """Cancel a refund of a payment."""
-    response.delete("https://api.mollie.com/v2/payments/%s/refunds/%s" % (PAYMENT_ID, REFUND_ID), "empty")
+    response.delete(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/refunds/{REFUND_ID}", "empty")
 
     canceled_refund = client.payment_refunds.with_parent_id(PAYMENT_ID).delete(REFUND_ID)
     assert canceled_refund == {}

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -50,7 +50,7 @@ def test_create_payment(client, response):
 
 def test_cancel_payment(client, response):
     """Cancel existing payment."""
-    response.delete("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_canceled", 200)
+    response.delete(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_canceled", 200)
 
     canceled_payment = client.payments.delete(PAYMENT_ID)
     assert isinstance(canceled_payment, Payment)
@@ -67,10 +67,10 @@ def test_cancel_payment_invalid_id(client):
 
 def test_get_single_payment(client, response):
     """Retrieve a single payment by payment id."""
-    response.get("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_single")
-    response.get("https://api.mollie.com/v2/payments/%s/refunds" % PAYMENT_ID, "refunds_list")
-    response.get("https://api.mollie.com/v2/payments/%s/chargebacks" % PAYMENT_ID, "chargebacks_list")
-    response.get("https://api.mollie.com/v2/customers/%s" % CUSTOMER_ID, "customer_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/refunds", "refunds_list")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/chargebacks", "chargebacks_list")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}", "customer_single")
     response.get(
         "https://api.mollie.com/v2/customers/{cust}/mandates/{man}".format(cust=CUSTOMER_ID, man=MANDATE_ID),
         "customer_mandate_single",
@@ -140,8 +140,8 @@ def test_get_single_payment(client, response):
 
 def test_payment_get_related_refunds(client, response):
     """Retrieve a list of refunds related to a payment."""
-    response.get("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_single")
-    response.get("https://api.mollie.com/v2/payments/%s/refunds" % PAYMENT_ID, "refunds_list")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/refunds", "refunds_list")
 
     payment = client.payments.get(PAYMENT_ID)
     refunds = payment.refunds
@@ -150,8 +150,8 @@ def test_payment_get_related_refunds(client, response):
 
 def test_payment_get_related_chargebacks(client, response):
     """Get chargebacks related to payment id."""
-    response.get("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_single")
-    response.get("https://api.mollie.com/v2/payments/%s/chargebacks" % PAYMENT_ID, "chargebacks_list")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/chargebacks", "chargebacks_list")
 
     payment = client.payments.get(PAYMENT_ID)
     chargebacks = payment.chargebacks
@@ -160,8 +160,8 @@ def test_payment_get_related_chargebacks(client, response):
 
 def test_payment_get_related_captures(client, response):
     """Get captures related to payment id."""
-    response.get("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_single")
-    response.get("https://api.mollie.com/v2/payments/%s/captures" % PAYMENT_ID, "captures_list")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/captures", "captures_list")
 
     payment = client.payments.get(PAYMENT_ID)
     captures = payment.captures
@@ -170,8 +170,8 @@ def test_payment_get_related_captures(client, response):
 
 def test_payment_get_related_settlement(client, response):
     """Get the settlement related to the payment."""
-    response.get("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_single")
-    response.get("https://api.mollie.com/v2/settlements/%s" % SETTLEMENT_ID, "settlement_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
+    response.get(f"https://api.mollie.com/v2/settlements/{SETTLEMENT_ID}", "settlement_single")
 
     payment = client.payments.get(PAYMENT_ID)
     settlement = payment.settlement
@@ -181,7 +181,7 @@ def test_payment_get_related_settlement(client, response):
 
 def test_payment_get_related_mandate(client, response):
     """Get the mandate related to the payment."""
-    response.get("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
     response.get(
         "https://api.mollie.com/v2/customers/{cust}/mandates/{man}".format(cust=CUSTOMER_ID, man=MANDATE_ID),
         "customer_mandate_single",
@@ -194,7 +194,7 @@ def test_payment_get_related_mandate(client, response):
 
 
 def test_payment_get_related_subscription(client, response):
-    response.get("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
     response.get(
         "https://api.mollie.com/v2/customers/{cust}/subscriptions/{sub}".format(cust=CUSTOMER_ID, sub=SUBSCRIPTION_ID),
         "subscription_single",
@@ -208,8 +208,8 @@ def test_payment_get_related_subscription(client, response):
 
 def test_payment_get_related_customer(client, response):
     """Get customer related to payment."""
-    response.get("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_single")
-    response.get("https://api.mollie.com/v2/customers/%s" % CUSTOMER_ID, "customer_single")
+    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
+    response.get(f"https://api.mollie.com/v2/customers/{CUSTOMER_ID}", "customer_single")
 
     payment = client.payments.get(PAYMENT_ID)
     customer = payment.customer
@@ -219,7 +219,7 @@ def test_payment_get_related_customer(client, response):
 
 def test_update_payment(client, response):
     """Update an existing payment."""
-    response.patch("https://api.mollie.com/v2/payments/%s" % PAYMENT_ID, "payment_updated")
+    response.patch(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_updated")
 
     data = {
         "description": "Order #12346",

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -19,7 +19,7 @@ def test_list_permissions(oauth_client, response):
 
 def test_get_permission(oauth_client, response):
     """Retrieve a single permission."""
-    response.get("https://api.mollie.com/v2/permissions/%s" % PERMISSION_ID, "permission_single")
+    response.get(f"https://api.mollie.com/v2/permissions/{PERMISSION_ID}", "permission_single")
 
     permission = oauth_client.permissions.get(PERMISSION_ID)
     assert isinstance(permission, Permission)

--- a/tests/test_profile_chargebacks.py
+++ b/tests/test_profile_chargebacks.py
@@ -7,7 +7,7 @@ PROFILE_ID = "pfl_v9hTwCvYqw"
 
 def test_get_profile_chargebacks_by_profile_id(client, response):
     """Get chargebacks relevant to profile by profile id."""
-    response.get("https://api.mollie.com/v2/chargebacks?profileId=%s" % PROFILE_ID, "chargebacks_list")
+    response.get(f"https://api.mollie.com/v2/chargebacks?profileId={PROFILE_ID}", "chargebacks_list")
 
     chargebacks = client.profile_chargebacks.with_parent_id(PROFILE_ID).list()
     assert_list_object(chargebacks, Chargeback)

--- a/tests/test_profile_methods.py
+++ b/tests/test_profile_methods.py
@@ -7,7 +7,7 @@ PROFILE_ID = "pfl_v9hTwCvYqw"
 
 def test_get_profile_methods_by_profile_id(client, response):
     """Get methods relevant to profile by profile id."""
-    response.get("https://api.mollie.com/v2/methods?profileId=%s" % PROFILE_ID, "methods_list")
+    response.get(f"https://api.mollie.com/v2/methods?profileId={PROFILE_ID}", "methods_list")
 
     methods = client.profile_methods.with_parent_id(PROFILE_ID).list()
     assert_list_object(methods, Method)

--- a/tests/test_profile_payments.py
+++ b/tests/test_profile_payments.py
@@ -7,7 +7,7 @@ PROFILE_ID = "pfl_v9hTwCvYqw"
 
 def test_get_profile_payments_by_profile_id(client, response):
     """Get payments relevant to profile by profile id."""
-    response.get("https://api.mollie.com/v2/payments?profileId=%s" % PROFILE_ID, "payments_list")
+    response.get(f"https://api.mollie.com/v2/payments?profileId={PROFILE_ID}", "payments_list")
 
     payments = client.profile_payments.with_parent_id(PROFILE_ID).list()
     assert_list_object(payments, Payment)

--- a/tests/test_profile_refunds.py
+++ b/tests/test_profile_refunds.py
@@ -7,7 +7,7 @@ PROFILE_ID = "pfl_v9hTwCvYqw"
 
 def test_get_profile_refunds_by_profile_id(client, response):
     """Get refunds relevant to profile by profile id."""
-    response.get("https://api.mollie.com/v2/refunds?profileId=%s" % PROFILE_ID, "refunds_list")
+    response.get(f"https://api.mollie.com/v2/refunds?profileId={PROFILE_ID}", "refunds_list")
 
     refunds = client.profile_refunds.with_parent_id(PROFILE_ID).list()
     assert_list_object(refunds, Refund)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -10,14 +10,14 @@ PROFILE_ID = "pfl_v9hTwCvYqw"
 
 
 def test_profile_resource_class(oauth_client, response):
-    response.get("https://api.mollie.com/v2/profiles/%s" % PROFILE_ID, "profile_single")
+    response.get(f"https://api.mollie.com/v2/profiles/{PROFILE_ID}", "profile_single")
     oauth_client.profiles.get(PROFILE_ID)
 
     assert isinstance(Profile.get_resource_class(oauth_client), Profiles)
 
 
 def test_profiles_get_raises_identifier_error(oauth_client, response):
-    response.get("https://api.mollie.com/v2/profiles/%s" % PROFILE_ID, "profile_single")
+    response.get(f"https://api.mollie.com/v2/profiles/{PROFILE_ID}", "profile_single")
     oauth_client.profiles.get(PROFILE_ID)
 
     with pytest.raises(IdentifierError):
@@ -44,7 +44,7 @@ def test_create_profile(oauth_client, response):
 
 def test_update_profile(oauth_client, response):
     """Update an existing profile."""
-    response.patch("https://api.mollie.com/v2/profiles/%s" % PROFILE_ID, "profile_updated")
+    response.patch(f"https://api.mollie.com/v2/profiles/{PROFILE_ID}", "profile_updated")
 
     updated_profile = oauth_client.profiles.update(
         PROFILE_ID,
@@ -60,7 +60,7 @@ def test_update_profile(oauth_client, response):
 
 def test_delete_profile(oauth_client, response):
     """Delete a profile."""
-    response.delete("https://api.mollie.com/v2/profiles/%s" % PROFILE_ID, "empty")
+    response.delete(f"https://api.mollie.com/v2/profiles/{PROFILE_ID}", "empty")
 
     deleted_profile = oauth_client.profiles.delete("pfl_v9hTwCvYqw")
     assert deleted_profile == {}
@@ -76,11 +76,11 @@ def test_list_profiles(oauth_client, response):
 
 def test_get_profile(oauth_client, response):
     """Retrieve a single profile."""
-    response.get("https://api.mollie.com/v2/profiles/%s" % PROFILE_ID, "profile_single")
-    response.get("https://api.mollie.com/v2/chargebacks?profileId=%s" % PROFILE_ID, "chargebacks_list")
-    response.get("https://api.mollie.com/v2/methods?profileId=%s" % PROFILE_ID, "methods_list")
-    response.get("https://api.mollie.com/v2/payments?profileId=%s" % PROFILE_ID, "payments_list")
-    response.get("https://api.mollie.com/v2/refunds?profileId=%s" % PROFILE_ID, "refunds_list")
+    response.get(f"https://api.mollie.com/v2/profiles/{PROFILE_ID}", "profile_single")
+    response.get(f"https://api.mollie.com/v2/chargebacks?profileId={PROFILE_ID}", "chargebacks_list")
+    response.get(f"https://api.mollie.com/v2/methods?profileId={PROFILE_ID}", "methods_list")
+    response.get(f"https://api.mollie.com/v2/payments?profileId={PROFILE_ID}", "payments_list")
+    response.get(f"https://api.mollie.com/v2/refunds?profileId={PROFILE_ID}", "refunds_list")
 
     profile = oauth_client.profiles.get(PROFILE_ID)
     chargebacks = oauth_client.profile_chargebacks.with_parent_id(PROFILE_ID).list()
@@ -111,9 +111,9 @@ def test_get_profile(oauth_client, response):
 
 
 def test_profile_enable_payment_method(oauth_client, response):
-    response.get("https://api.mollie.com/v2/profiles/%s" % PROFILE_ID, "profile_new")
+    response.get(f"https://api.mollie.com/v2/profiles/{PROFILE_ID}", "profile_new")
     response.post(
-        "https://api.mollie.com/v2/profiles/%s/methods/%s" % (PROFILE_ID, "bancontact"),
+        f"https://api.mollie.com/v2/profiles/{PROFILE_ID}/methods/bancontact",
         "profile_enable_payment_method",
     )
 
@@ -123,8 +123,8 @@ def test_profile_enable_payment_method(oauth_client, response):
 
 
 def test_profile_disable_payment_method(oauth_client, response):
-    response.get("https://api.mollie.com/v2/profiles/%s" % PROFILE_ID, "profile_new")
-    response.delete("https://api.mollie.com/v2/profiles/%s/methods/%s" % (PROFILE_ID, "bancontact"), "empty", 204)
+    response.get(f"https://api.mollie.com/v2/profiles/{PROFILE_ID}", "profile_new")
+    response.delete(f"https://api.mollie.com/v2/profiles/{PROFILE_ID}/methods/bancontact", "empty", 204)
 
     profile = oauth_client.profiles.get(PROFILE_ID)
     method = oauth_client.profile_methods.on(profile, "bancontact").delete()
@@ -133,7 +133,7 @@ def test_profile_disable_payment_method(oauth_client, response):
 
 @pytest.mark.parametrize("method", ["giftcard", "voucher"])
 def test_profile_enable_giftcard_no_resource_id(oauth_client, response, method):
-    response.get("https://api.mollie.com/v2/profiles/%s" % PROFILE_ID, "profile_new")
+    response.get(f"https://api.mollie.com/v2/profiles/{PROFILE_ID}", "profile_new")
 
     profile = oauth_client.profiles.get(PROFILE_ID)
 
@@ -143,9 +143,9 @@ def test_profile_enable_giftcard_no_resource_id(oauth_client, response, method):
 
 @pytest.mark.parametrize("method", ["giftcard", "voucher"])
 def test_profile_enable_giftcard(oauth_client, response, method):
-    response.get("https://api.mollie.com/v2/profiles/%s" % PROFILE_ID, "profile_new")
+    response.get(f"https://api.mollie.com/v2/profiles/{PROFILE_ID}", "profile_new")
     response.post(
-        "https://api.mollie.com/v2/profiles/%s/methods/%s/issuers/%s" % (PROFILE_ID, method, "festivalcadeau"),
+        f"https://api.mollie.com/v2/profiles/{PROFILE_ID}/methods/{method}/issuers/festivalcadeau",
         "profile_enable_gift_card_issuer",
     )
 
@@ -157,9 +157,9 @@ def test_profile_enable_giftcard(oauth_client, response, method):
 
 @pytest.mark.parametrize("method", ["giftcard", "voucher"])
 def test_profile_disable_giftcard(oauth_client, response, method):
-    response.get("https://api.mollie.com/v2/profiles/%s" % PROFILE_ID, "profile_new")
+    response.get(f"https://api.mollie.com/v2/profiles/{PROFILE_ID}", "profile_new")
     response.delete(
-        "https://api.mollie.com/v2/profiles/%s/methods/%s/issuers/%s" % (PROFILE_ID, method, "festivalcadeau"),
+        f"https://api.mollie.com/v2/profiles/{PROFILE_ID}/methods/{method}/issuers/festivalcadeau",
         "empty",
         204,
     )

--- a/tests/test_settlement_captures.py
+++ b/tests/test_settlement_captures.py
@@ -9,7 +9,7 @@ CHARGEBACK_ID = "chb_n9z0tp"
 
 def test_get_settlement_captures_by_capture_id(oauth_client, response):
     """Get captures relevant to settlement by settlement id."""
-    response.get("https://api.mollie.com/v2/settlements/%s/captures" % SETTLEMENT_ID, "captures_list")
+    response.get(f"https://api.mollie.com/v2/settlements/{SETTLEMENT_ID}/captures", "captures_list")
 
     captures = oauth_client.settlement_captures.with_parent_id(SETTLEMENT_ID).list()
     assert_list_object(captures, Capture)
@@ -17,8 +17,8 @@ def test_get_settlement_captures_by_capture_id(oauth_client, response):
 
 def test_list_settlement_captures_by_capture_object(oauth_client, response):
     """Get a list of captures relevant to settlement object."""
-    response.get("https://api.mollie.com/v2/settlements/%s/captures" % SETTLEMENT_ID, "captures_list")
-    response.get("https://api.mollie.com/v2/settlements/%s" % SETTLEMENT_ID, "settlement_single")
+    response.get(f"https://api.mollie.com/v2/settlements/{SETTLEMENT_ID}/captures", "captures_list")
+    response.get(f"https://api.mollie.com/v2/settlements/{SETTLEMENT_ID}", "settlement_single")
 
     settlement = oauth_client.settlements.get(SETTLEMENT_ID)
     captures = oauth_client.settlement_captures.on(settlement).list()

--- a/tests/test_settlement_chargebacks.py
+++ b/tests/test_settlement_chargebacks.py
@@ -9,7 +9,7 @@ CHARGEBACK_ID = "chb_n9z0tp"
 
 def test_get_settlement_chargebacks_by_chargeback_id(oauth_client, response):
     """Get chargebacks relevant to settlement by settlement id."""
-    response.get("https://api.mollie.com/v2/settlements/%s/chargebacks" % SETTLEMENT_ID, "chargebacks_list")
+    response.get(f"https://api.mollie.com/v2/settlements/{SETTLEMENT_ID}/chargebacks", "chargebacks_list")
 
     chargebacks = oauth_client.settlement_chargebacks.with_parent_id(SETTLEMENT_ID).list()
     assert_list_object(chargebacks, Chargeback)
@@ -17,8 +17,8 @@ def test_get_settlement_chargebacks_by_chargeback_id(oauth_client, response):
 
 def test_list_settlement_chargebacks_by_settlement_object(oauth_client, response):
     """Get a list of chargebacks relevant to settlement object."""
-    response.get("https://api.mollie.com/v2/settlements/%s/chargebacks" % SETTLEMENT_ID, "chargebacks_list")
-    response.get("https://api.mollie.com/v2/settlements/%s" % SETTLEMENT_ID, "settlement_single")
+    response.get(f"https://api.mollie.com/v2/settlements/{SETTLEMENT_ID}/chargebacks", "chargebacks_list")
+    response.get(f"https://api.mollie.com/v2/settlements/{SETTLEMENT_ID}", "settlement_single")
 
     settlement = oauth_client.settlements.get(SETTLEMENT_ID)
     chargebacks = oauth_client.settlement_chargebacks.on(settlement).list()

--- a/tests/test_settlement_payments.py
+++ b/tests/test_settlement_payments.py
@@ -7,7 +7,7 @@ SETTLEMENT_ID = "stl_jDk30akdN"
 
 def test_list_customer_payments(oauth_client, response):
     """Retrieve a list of payments related to a settlement id."""
-    response.get("https://api.mollie.com/v2/settlements/%s/payments" % SETTLEMENT_ID, "settlement_payments_multiple")
+    response.get(f"https://api.mollie.com/v2/settlements/{SETTLEMENT_ID}/payments", "settlement_payments_multiple")
 
     payments = oauth_client.settlement_payments.with_parent_id(SETTLEMENT_ID).list()
     assert_list_object(payments, Payment)

--- a/tests/test_settlement_refunds.py
+++ b/tests/test_settlement_refunds.py
@@ -8,8 +8,8 @@ SETTLEMENT_ID = "stl_jDk30akdN"
 
 def test_list_refunds_on_settlement_object(oauth_client, response):
     """Retrieve a list of payment refunds of a payment."""
-    response.get("https://api.mollie.com/v2/settlements/%s" % SETTLEMENT_ID, "settlement_single")
-    response.get("https://api.mollie.com/v2/settlements/%s/refunds" % SETTLEMENT_ID, "refunds_list")
+    response.get(f"https://api.mollie.com/v2/settlements/{SETTLEMENT_ID}", "settlement_single")
+    response.get(f"https://api.mollie.com/v2/settlements/{SETTLEMENT_ID}/refunds", "refunds_list")
 
     settlement = oauth_client.settlements.get(SETTLEMENT_ID)
     assert isinstance(settlement, Settlement)

--- a/tests/test_settlements.py
+++ b/tests/test_settlements.py
@@ -20,10 +20,10 @@ def test_list_settlements(oauth_client, response):
 
 def test_settlement_get(oauth_client, response):
     """Retrieve a single settlement method by ID."""
-    response.get("https://api.mollie.com/v2/settlements/%s" % SETTLEMENT_ID, "settlement_single")
-    response.get("https://api.mollie.com/v2/settlements/%s/chargebacks" % SETTLEMENT_ID, "chargebacks_list")
-    response.get("https://api.mollie.com/v2/settlements/%s/payments" % SETTLEMENT_ID, "settlement_payments_multiple")
-    response.get("https://api.mollie.com/v2/settlements/%s/refunds" % SETTLEMENT_ID, "refunds_list")
+    response.get(f"https://api.mollie.com/v2/settlements/{SETTLEMENT_ID}", "settlement_single")
+    response.get(f"https://api.mollie.com/v2/settlements/{SETTLEMENT_ID}/chargebacks", "chargebacks_list")
+    response.get(f"https://api.mollie.com/v2/settlements/{SETTLEMENT_ID}/payments", "settlement_payments_multiple")
+    response.get(f"https://api.mollie.com/v2/settlements/{SETTLEMENT_ID}/refunds", "refunds_list")
 
     settlement = oauth_client.settlements.get(SETTLEMENT_ID)
     chargebacks = oauth_client.settlement_chargebacks.with_parent_id(SETTLEMENT_ID).list()
@@ -184,7 +184,7 @@ def test_validate_settlement_id(input, expected):
 
 
 def test_settlement_invoice_id_is_deprecated(oauth_client, response):
-    response.get("https://api.mollie.com/v2/settlements/%s" % SETTLEMENT_ID, "settlement_single")
+    response.get(f"https://api.mollie.com/v2/settlements/{SETTLEMENT_ID}", "settlement_single")
 
     settlement = oauth_client.settlements.get(SETTLEMENT_ID)
     with pytest.warns(APIDeprecationWarning, match="Using Settlement Invoice ID is deprecated"):


### PR DESCRIPTION
Remove deprecated string interpolation syntax. Since we now support python 3.6 and up, replace everything with f-strings.