### PR TITLE
Rename 'Base' classes with duplicate names.

### DIFF
--- a/mollie/api/objects/base.py
+++ b/mollie/api/objects/base.py
@@ -1,4 +1,4 @@
-class Base(dict):
+class ObjectBase(dict):
     def __init__(self, data, client=None):
         """
         Create a new object from API result data.

--- a/mollie/api/objects/capture.py
+++ b/mollie/api/objects/capture.py
@@ -1,7 +1,7 @@
-from .base import Base
+from .base import ObjectBase
 
 
-class Capture(Base):
+class Capture(ObjectBase):
     @classmethod
     def get_resource_class(cls, client):
         from ..resources.captures import Captures

--- a/mollie/api/objects/chargeback.py
+++ b/mollie/api/objects/chargeback.py
@@ -1,7 +1,7 @@
-from .base import Base
+from .base import ObjectBase
 
 
-class Chargeback(Base):
+class Chargeback(ObjectBase):
     @classmethod
     def get_resource_class(cls, client):
         from ..resources.chargebacks import Chargebacks

--- a/mollie/api/objects/customer.py
+++ b/mollie/api/objects/customer.py
@@ -1,7 +1,7 @@
-from .base import Base
+from .base import ObjectBase
 
 
-class Customer(Base):
+class Customer(ObjectBase):
     @classmethod
     def get_resource_class(cls, client):
         from ..resources.customers import Customers

--- a/mollie/api/objects/invoice.py
+++ b/mollie/api/objects/invoice.py
@@ -1,7 +1,7 @@
-from .base import Base
+from .base import ObjectBase
 
 
-class Invoice(Base):
+class Invoice(ObjectBase):
     @classmethod
     def get_resource_class(cls, client):
         from ..resources.invoices import Invoices

--- a/mollie/api/objects/issuer.py
+++ b/mollie/api/objects/issuer.py
@@ -1,7 +1,7 @@
-from .base import Base
+from .base import ObjectBase
 
 
-class Issuer(Base):
+class Issuer(ObjectBase):
     @property
     def resource(self):
         return self._get_property("resource")

--- a/mollie/api/objects/list.py
+++ b/mollie/api/objects/list.py
@@ -1,7 +1,7 @@
-from .base import Base
+from .base import ObjectBase
 
 
-class List(Base):
+class List(ObjectBase):
     current = None
 
     def __init__(self, result, object_type, client=None):

--- a/mollie/api/objects/mandate.py
+++ b/mollie/api/objects/mandate.py
@@ -1,7 +1,7 @@
-from .base import Base
+from .base import ObjectBase
 
 
-class Mandate(Base):
+class Mandate(ObjectBase):
     @classmethod
     def get_resource_class(cls, client):
         from ..resources.customer_mandates import CustomerMandates

--- a/mollie/api/objects/method.py
+++ b/mollie/api/objects/method.py
@@ -1,9 +1,9 @@
-from .base import Base
+from .base import ObjectBase
 from .issuer import Issuer
 from .list import List
 
 
-class Method(Base):
+class Method(ObjectBase):
     @classmethod
     def get_resource_class(cls, client):
         from ..resources.methods import Methods

--- a/mollie/api/objects/onboarding.py
+++ b/mollie/api/objects/onboarding.py
@@ -1,7 +1,7 @@
-from .base import Base
+from .base import ObjectBase
 
 
-class Onboarding(Base):
+class Onboarding(ObjectBase):
     @classmethod
     def get_resource_class(cls, client):
         from ..resources.onboarding import Onboarding as OnboardingResource

--- a/mollie/api/objects/order.py
+++ b/mollie/api/objects/order.py
@@ -3,13 +3,13 @@ from ..resources.order_lines import OrderLines
 from ..resources.order_payments import OrderPayments
 from ..resources.order_refunds import OrderRefunds
 from ..resources.shipments import Shipments
-from .base import Base
+from .base import ObjectBase
 from .list import List
 from .order_line import OrderLine
 from .payment import Payment
 
 
-class Order(Base):
+class Order(ObjectBase):
     requested_embeds = None
 
     def __init__(self, data, client=None, requested_embeds=None):

--- a/mollie/api/objects/order_line.py
+++ b/mollie/api/objects/order_line.py
@@ -1,7 +1,7 @@
-from .base import Base
+from .base import ObjectBase
 
 
-class OrderLine(Base):
+class OrderLine(ObjectBase):
     @classmethod
     def get_resource_class(cls, client):
         from ..resources.order_lines import OrderLines

--- a/mollie/api/objects/organization.py
+++ b/mollie/api/objects/organization.py
@@ -1,7 +1,7 @@
-from .base import Base
+from .base import ObjectBase
 
 
-class Organization(Base):
+class Organization(ObjectBase):
     @classmethod
     def get_resource_class(cls, client):
         from ..resources.organizations import Organizations

--- a/mollie/api/objects/payment.py
+++ b/mollie/api/objects/payment.py
@@ -1,7 +1,7 @@
-from .base import Base
+from .base import ObjectBase
 
 
-class Payment(Base):
+class Payment(ObjectBase):
     @classmethod
     def get_resource_class(cls, client):
         from ..resources.payments import Payments

--- a/mollie/api/objects/payment_link.py
+++ b/mollie/api/objects/payment_link.py
@@ -1,7 +1,7 @@
-from .base import Base
+from .base import ObjectBase
 
 
-class PaymentLink(Base):
+class PaymentLink(ObjectBase):
     @classmethod
     def get_resource_class(cls, client):
         from ..resources.payment_links import PaymentLinks

--- a/mollie/api/objects/permission.py
+++ b/mollie/api/objects/permission.py
@@ -1,7 +1,7 @@
-from .base import Base
+from .base import ObjectBase
 
 
-class Permission(Base):
+class Permission(ObjectBase):
     @classmethod
     def get_resource_class(cls, client):
         from ..resources.permissions import Permissions

--- a/mollie/api/objects/profile.py
+++ b/mollie/api/objects/profile.py
@@ -1,7 +1,7 @@
-from .base import Base
+from .base import ObjectBase
 
 
-class Profile(Base):
+class Profile(ObjectBase):
     STATUS_UNVERIFIED = "unverified"
     STATUS_VERIFIED = "verified"
     STATUS_BLOCKED = "blocked"

--- a/mollie/api/objects/refund.py
+++ b/mollie/api/objects/refund.py
@@ -1,9 +1,9 @@
-from .base import Base
+from .base import ObjectBase
 from .list import List
 from .order_line import OrderLine
 
 
-class Refund(Base):
+class Refund(ObjectBase):
     @classmethod
     def get_resource_class(cls, client):
         from ..resources.refunds import Refunds

--- a/mollie/api/objects/settlement.py
+++ b/mollie/api/objects/settlement.py
@@ -1,10 +1,10 @@
 import warnings
 
 from ..error import APIDeprecationWarning
-from .base import Base
+from .base import ObjectBase
 
 
-class Settlement(Base):
+class Settlement(ObjectBase):
     STATUS_OPEN = "open"
     STATUS_PENDING = "pending"
     STATUS_PAIDOUT = "paidout"

--- a/mollie/api/objects/shipment.py
+++ b/mollie/api/objects/shipment.py
@@ -1,9 +1,9 @@
-from .base import Base
+from .base import ObjectBase
 from .list import List
 from .order_line import OrderLine
 
 
-class Shipment(Base):
+class Shipment(ObjectBase):
     @property
     def resource(self):
         return self._get_property("resource")

--- a/mollie/api/objects/subscription.py
+++ b/mollie/api/objects/subscription.py
@@ -1,8 +1,8 @@
-from .base import Base
+from .base import ObjectBase
 from .customer import Customer
 
 
-class Subscription(Base):
+class Subscription(ObjectBase):
     @classmethod
     def get_resource_class(cls, client):
         from ..resources.customer_subscriptions import CustomerSubscriptions

--- a/mollie/api/resources/base.py
+++ b/mollie/api/resources/base.py
@@ -2,7 +2,7 @@ from ..error import ResponseError, ResponseHandlingError
 from ..objects.list import List
 
 
-class Base(object):
+class ResourceBase(object):
     REST_CREATE = "POST"
     REST_UPDATE = "PATCH"
     REST_READ = "GET"

--- a/mollie/api/resources/captures.py
+++ b/mollie/api/resources/captures.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.capture import Capture
-from .base import Base
+from .base import ResourceBase
 
 
-class Captures(Base):
+class Captures(ResourceBase):
     RESOURCE_ID_PREFIX = "cpt_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/chargebacks.py
+++ b/mollie/api/resources/chargebacks.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.chargeback import Chargeback
-from .base import Base
+from .base import ResourceBase
 
 
-class Chargebacks(Base):
+class Chargebacks(ResourceBase):
     RESOURCE_ID_PREFIX = "chb_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/customer_mandates.py
+++ b/mollie/api/resources/customer_mandates.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.mandate import Mandate
-from .base import Base
+from .base import ResourceBase
 
 
-class CustomerMandates(Base):
+class CustomerMandates(ResourceBase):
     RESOURCE_ID_PREFIX = "mdt_"
     customer_id = None
 

--- a/mollie/api/resources/customer_subscriptions.py
+++ b/mollie/api/resources/customer_subscriptions.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.subscription import Subscription
-from .base import Base
+from .base import ResourceBase
 
 
-class CustomerSubscriptions(Base):
+class CustomerSubscriptions(ResourceBase):
     RESOURCE_ID_PREFIX = "sub_"
     customer_id = None
 

--- a/mollie/api/resources/customers.py
+++ b/mollie/api/resources/customers.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.customer import Customer
-from .base import Base
+from .base import ResourceBase
 
 
-class Customers(Base):
+class Customers(ResourceBase):
     RESOURCE_ID_PREFIX = "cst_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/invoices.py
+++ b/mollie/api/resources/invoices.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.invoice import Invoice
-from .base import Base
+from .base import ResourceBase
 
 
-class Invoices(Base):
+class Invoices(ResourceBase):
     RESOURCE_ID_PREFIX = "inv_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/methods.py
+++ b/mollie/api/resources/methods.py
@@ -1,9 +1,9 @@
 from ..objects.list import List
 from ..objects.method import Method
-from .base import Base
+from .base import ResourceBase
 
 
-class Methods(Base):
+class Methods(ResourceBase):
     def get_resource_object(self, result):
         return Method(result)
 

--- a/mollie/api/resources/onboarding.py
+++ b/mollie/api/resources/onboarding.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.onboarding import Onboarding as OnboardingObject
-from .base import Base
+from .base import ResourceBase
 
 
-class Onboarding(Base):
+class Onboarding(ResourceBase):
     def get_resource_object(self, result):
         return OnboardingObject(result, self.client)
 

--- a/mollie/api/resources/order_lines.py
+++ b/mollie/api/resources/order_lines.py
@@ -1,9 +1,9 @@
 from ..error import DataConsistencyError
 from ..objects.order_line import OrderLine
-from .base import Base
+from .base import ResourceBase
 
 
-class OrderLines(Base):
+class OrderLines(ResourceBase):
     order_id = None
 
     def get_resource_name(self):

--- a/mollie/api/resources/orders.py
+++ b/mollie/api/resources/orders.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.order import Order
-from .base import Base
+from .base import ResourceBase
 
 
-class Orders(Base):
+class Orders(ResourceBase):
     RESOURCE_ID_PREFIX = "ord_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/organizations.py
+++ b/mollie/api/resources/organizations.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.organization import Organization
-from .base import Base
+from .base import ResourceBase
 
 
-class Organizations(Base):
+class Organizations(ResourceBase):
     RESOURCE_ID_PREFIX = "org_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/payment_links.py
+++ b/mollie/api/resources/payment_links.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.payment_link import PaymentLink
-from .base import Base
+from .base import ResourceBase
 
 
-class PaymentLinks(Base):
+class PaymentLinks(ResourceBase):
     RESOURCE_ID_PREFIX = "pl_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/payments.py
+++ b/mollie/api/resources/payments.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.payment import Payment
-from .base import Base
+from .base import ResourceBase
 
 
-class Payments(Base):
+class Payments(ResourceBase):
     RESOURCE_ID_PREFIX = "tr_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/permissions.py
+++ b/mollie/api/resources/permissions.py
@@ -2,10 +2,10 @@ import re
 
 from ..error import IdentifierError
 from ..objects.permission import Permission
-from .base import Base
+from .base import ResourceBase
 
 
-class Permissions(Base):
+class Permissions(ResourceBase):
     def get_resource_object(self, result):
         return Permission(result, self.client)
 

--- a/mollie/api/resources/profiles.py
+++ b/mollie/api/resources/profiles.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.profile import Profile
-from .base import Base
+from .base import ResourceBase
 
 
-class Profiles(Base):
+class Profiles(ResourceBase):
     RESOURCE_ID_PREFIX = "pfl_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/refunds.py
+++ b/mollie/api/resources/refunds.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.refund import Refund
-from .base import Base
+from .base import ResourceBase
 
 
-class Refunds(Base):
+class Refunds(ResourceBase):
     RESOURCE_ID_PREFIX = "re_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/settlements.py
+++ b/mollie/api/resources/settlements.py
@@ -2,10 +2,10 @@ import re
 
 from ..error import IdentifierError
 from ..objects.settlement import Settlement
-from .base import Base
+from .base import ResourceBase
 
 
-class Settlements(Base):
+class Settlements(ResourceBase):
     RESOURCE_ID_PREFIX = "stl_"
 
     # According to Mollie, the bank reference is formatted as:

--- a/mollie/api/resources/shipments.py
+++ b/mollie/api/resources/shipments.py
@@ -1,8 +1,8 @@
 from ..objects.shipment import Shipment
-from .base import Base
+from .base import ResourceBase
 
 
-class Shipments(Base):
+class Shipments(ResourceBase):
     order_id = None
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/subscriptions.py
+++ b/mollie/api/resources/subscriptions.py
@@ -1,8 +1,8 @@
 from ..objects.subscription import Subscription
-from .base import Base
+from .base import ResourceBase
 
 
-class Subscriptions(Base):
+class Subscriptions(ResourceBase):
     def get_resource_object(self, result):
         return Subscription(result, self.client)
 


### PR DESCRIPTION
This solves a long-standing itch from a developer view.