### PR TITLE
Changed default encoding to utf-8 & closed file descriptor

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,8 @@ class ImprovedRequestsMock(responses.RequestsMock):
     def _get_body(self, filename):
         """Read the response fixture file and return it."""
         file = os.path.join(os.path.dirname(__file__), "responses", f"{filename}.json")
-        return open(file).read()
+        with open(file, encoding="utf-8") as f:
+            return f.read()
 
 
 @pytest.fixture


### PR DESCRIPTION
During local development `tests/test_client.py::test_client_unicode_error` failed. Apparently, this was due to the fact that `tests/conftest::ImprovedRequestsMock::_get_body` relied on system default encoding, which is not always utf-8 (in my case cp1252).

`open` [according to python.org](https://docs.python.org/3/library/functions.html#open)
> The default encoding is platform dependent (whatever locale.getpreferredencoding() returns)

The same method also did not close the file descriptor returned by `open `properly. Now it is contextmanaged and closes.