### PR TITLE
Omit useless API calls for data related to payments.

### DIFF
--- a/mollie/api/objects/payment.py
+++ b/mollie/api/objects/payment.py
@@ -1,4 +1,5 @@
 from .base import ObjectBase
+from .list import ObjectList
 
 
 class Payment(ObjectBase):
@@ -171,37 +172,48 @@ class Payment(ObjectBase):
     @property
     def refunds(self):
         """Return the refunds related to this payment."""
+        if not self.has_refunds():
+            return ObjectList({}, None)
         return self.client.payment_refunds.on(self).list()
 
     @property
     def chargebacks(self):
         """Return the chargebacks related to this payment."""
+        if not self.has_chargebacks():
+            return ObjectList({}, None)
         return self.client.payment_chargebacks.on(self).list()
 
     @property
     def captures(self):
         """Return the captures related to this payment"""
+        if not self.has_captures():
+            return ObjectList({}, None)
+
         return self.client.captures.on(self).list()
 
     @property
     def settlement(self):
         """Return the settlement for this payment."""
-        return self.client.settlements.get(self.settlement_id)
+        if self.settlement_id:
+            return self.client.settlements.get(self.settlement_id)
 
     @property
     def mandate(self):
         """Return the mandate for this payment."""
-        return self.client.customer_mandates.with_parent_id(self.customer_id).get(self.mandate_id)
+        if self.customer_id and self.mandate_id:
+            return self.client.customer_mandates.with_parent_id(self.customer_id).get(self.mandate_id)
 
     @property
     def subscription(self):
         """Return the subscription for this payment."""
-        return self.client.customer_subscriptions.with_parent_id(self.customer_id).get(self.subscription_id)
+        if self.customer_id and self.mandate_id:
+            return self.client.customer_subscriptions.with_parent_id(self.customer_id).get(self.subscription_id)
 
     @property
     def customer(self):
         """Return the customer for this payment."""
-        return self.client.customers.get(self.customer_id)
+        if self.customer_id:
+            return self.client.customers.get(self.customer_id)
 
     @property
     def order(self):

--- a/tests/responses/payment_single_no_links.json
+++ b/tests/responses/payment_single_no_links.json
@@ -1,0 +1,76 @@
+{
+  "resource": "payment",
+  "id": "tr_7UhSN1zuXS",
+  "mode": "test",
+  "createdAt": "2018-03-20T09:13:37+00:00",
+  "amount": {
+    "value": "10.00",
+    "currency": "EUR"
+  },
+  "description": "Order #12345",
+  "method": "ideal",
+  "metadata": {
+    "order_id": "12345"
+  },
+  "status": "open",
+  "isCancelable": false,
+  "amountCaptured": {
+    "value": "1.00",
+    "currency": "EUR"
+  },
+  "amountChargedBack": {
+    "value": "5.00",
+    "currency": "EUR"
+  },
+  "expiresAt": "2018-03-20T09:28:37+00:00",
+  "details": null,
+  "profileId": "pfl_QkEhN94Ba",
+  "customerId": "cst_8wmqcHMN4U",
+  "sequenceType": "recurring",
+  "redirectUrl": "https://webshop.example.org/order/12345/",
+  "webhookUrl": "https://webshop.example.org/payments/webhook/",
+  "routing": [
+    {
+      "resource": "route",
+      "id": "rt_k6cjd01h",
+      "amount": {
+        "value": "2.50",
+        "currency": "EUR"
+      },
+      "destination": {
+        "type": "organization",
+        "organizationId": "me"
+      }
+    },
+    {
+      "resource": "route",
+      "id": "rt_9dk4al1n",
+      "amount": {
+        "value": "7.50",
+        "currency": "EUR"
+      },
+      "destination": {
+        "type": "organization",
+        "organizationId": "org_23456"
+      }
+    }
+  ],
+  "_links": {
+    "self": {
+      "href": "https://api.mollie.com/v2/payments/tr_7UhSN1zuXS",
+      "type": "application/hal+json"
+    },
+    "checkout": {
+      "href": "https://www.mollie.com/payscreen/select-method/7UhSN1zuXS",
+      "type": "text/html"
+    },
+    "customer": {
+      "href": "https://api.mollie.com/v2/customers/cst_8wmqcHMN4U",
+      "type": "application/hal+json"
+    },
+    "documentation": {
+      "href": "https://docs.mollie.com/reference/v2/payments-api/create-payment",
+      "type": "text/html"
+    }
+  }
+}


### PR DESCRIPTION
If the payment contains no links to related objects, then omit the API call before returning an empty Object or ObjectList.