### PR TITLE
Fix responses deprecation warning

### DIFF
--- a/mollie/api/client.py
+++ b/mollie/api/client.py
@@ -311,19 +311,16 @@ def generate_querystring(params):
 
     The Requests library doesn't know how to generate querystrings that encode dictionaries using square brackets:
     https://api.mollie.com/v2/methods?amount[value]=100.00&amount[currency]=USD
-
-    Note: we use `sorted()` to work around a difference in iteration behaviour between Python 2 and 3.
-    This makes the output predictable, and ordering of querystring parameters shouldn't matter.
     """
     if not params:
         return None
     parts = []
-    for param, value in sorted(params.items()):
+    for param, value in params.items():
         if not isinstance(value, dict):
             parts.append(urlencode({param: value}))
         else:
             # encode dictionary with square brackets
-            for key, sub_value in sorted(value.items()):
+            for key, sub_value in value.items():
                 composed = f"{param}[{key}]"
                 parts.append(urlencode({composed: sub_value}))
     if parts:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,5 +5,5 @@ pytest-isort
 pytest-flake8
 pytest-mock
 mock
-responses
+responses>=0.17.0
 safety

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 import pytest
 import requests.adapters
+from responses import matchers
 
 from mollie.api.client import Client, generate_querystring
 from mollie.api.error import (
@@ -42,9 +43,9 @@ def test_client_querystring(client, response):
     """Verify that we are triggering the correct URL when using querystring with square brackets."""
     response.add(
         response.GET,
-        "https://api.mollie.com/v2/methods?amount[currency]=USD&amount[value]=100.00",
+        "https://api.mollie.com/v2/methods",
         body=response._get_body("methods_list"),
-        match_querystring=True,
+        match=[matchers.query_string_matcher("amount%5Bvalue%5D=100.00&amount%5Bcurrency%5D=USD")],
     )
 
     params = {"amount": {"currency": "USD", "value": "100.00"}}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -28,8 +28,8 @@ from .utils import assert_list_object
     [
         ({}, None),
         ({"locale": "nl_NL"}, "locale=nl_NL"),
-        ({"locale": "nl_NL", "hoeba": "kek"}, "hoeba=kek&locale=nl_NL"),
-        ({"amount": {"value": "100.00", "currency": "USD"}}, "amount%5Bcurrency%5D=USD&amount%5Bvalue%5D=100.00"),
+        ({"locale": "nl_NL", "hoeba": "kek"}, "locale=nl_NL&hoeba=kek"),
+        ({"amount": {"value": "100.00", "currency": "USD"}}, "amount%5Bvalue%5D=100.00&amount%5Bcurrency%5D=USD"),
     ],
 )
 def test_generate_querystring(params, querystring):

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from responses import matchers
 
 from mollie.api.error import EmbedNotFound
 from mollie.api.objects.order import Order
@@ -84,9 +85,9 @@ def test_get_order(client, response):
 def test_get_order_with_payments(client, response):
     response.add(
         response.GET,
-        f"https://api.mollie.com/v2/orders/{ORDER_ID}?embed=payments",
+        f"https://api.mollie.com/v2/orders/{ORDER_ID}",
         body=response._get_body("order_single_with_embeds"),
-        match_querystring=True,
+        match=[matchers.query_param_matcher({"embed": "payments"})],
     )
 
     order = client.orders.get(ORDER_ID, embed="payments")
@@ -105,9 +106,9 @@ def test_get_order_with_payments_embed_error(client, response):
 def test_get_order_with_payments_empty_embed(client, response):
     response.add(
         response.GET,
-        f"https://api.mollie.com/v2/orders/{ORDER_ID}?embed=payments",
+        f"https://api.mollie.com/v2/orders/{ORDER_ID}",
         body=response._get_body("order_single"),
-        match_querystring=True,
+        match=[matchers.query_param_matcher({"embed": "payments"})],
     )
 
     order = client.orders.get(ORDER_ID, embed="payments")


### PR DESCRIPTION
See https://github.com/getsentry/responses#deprecations-and-migration-path:

``Deprecated Functionality: match_querystring argument in Response and CallbackResponse``.