### PR TITLE
Remove references to deprecated Python 3.6.

### DIFF
--- a/.github/workflows/test_and_deploy.yaml
+++ b/.github/workflows/test_and_deploy.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
+        python_version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To use the Mollie API client, the following things are required:
 + Create a new [Website profile](https://www.mollie.com/dashboard/settings/profiles) to generate API keys and setup your webhook.
 + Now you're ready to use the Mollie API client in test mode.
 + Follow [a few steps](https://www.mollie.com/dashboard/?modal=onboarding) to enable payment methods in live mode, and let us handle the rest.
-+ Python >= 3.6
++ Python >= 3.7
 + Up-to-date OpenSSL (or other SSL/TLS toolkit)
 + Mollie API client for Python has a dependency on [Requests](http://docs.python-requests.org/en/master/) and [Requests-OAuthlib](https://requests-oauthlib.readthedocs.io/en/latest/)
 
@@ -30,7 +30,7 @@ $ pip install mollie-api-python
 ```
 You may also git checkout or [download all the files](https://github.com/mollie/mollie-api-python/archive/master.zip), and include the Mollie API client manually.
 
-Create and activate a Python >= 3.6 virtual environment (inside a git checkout or downloaded archive).
+Create and activate a Python >= 3.7 virtual environment (inside a git checkout or downloaded archive).
 
 ```shell
 $ cd mollie-api-python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 119
-target-version = ['py39']
+target-version = ['py310']
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
It should still work but we don't test or support it actively anymore.