### PR TITLE
Remove unused resource methods.

### DIFF
--- a/mollie/api/resources/base.py
+++ b/mollie/api/resources/base.py
@@ -94,3 +94,9 @@ class ResourceDeleteMixin:
     def delete(self, resource_id, data=None):
         path = self.get_resource_name() + "/" + str(resource_id)
         return self.perform_api_call(self.REST_DELETE, path, data)
+
+
+class ResourceAllMethodsMixin(
+    ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin
+):
+    pass

--- a/mollie/api/resources/base.py
+++ b/mollie/api/resources/base.py
@@ -3,11 +3,6 @@ from ..objects.list import ObjectList
 
 
 class ResourceBase(object):
-    REST_CREATE = "POST"
-    REST_UPDATE = "PATCH"
-    REST_READ = "GET"
-    REST_LIST = "GET"
-    REST_DELETE = "DELETE"
     DEFAULT_LIMIT = 10
 
     def __init__(self, client):
@@ -18,30 +13,6 @@ class ResourceBase(object):
 
     def get_resource_name(self):
         return self.__class__.__name__.lower()
-
-    def create(self, data=None, **params):
-        path = self.get_resource_name()
-        result = self.perform_api_call(self.REST_CREATE, path, data, params)
-        return self.get_resource_object(result)
-
-    def get(self, resource_id, **params):
-        path = self.get_resource_name() + "/" + str(resource_id)
-        result = self.perform_api_call(self.REST_READ, path, params=params)
-        return self.get_resource_object(result)
-
-    def update(self, resource_id, data=None, **params):
-        path = self.get_resource_name() + "/" + str(resource_id)
-        result = self.perform_api_call(self.REST_UPDATE, path, data, params)
-        return self.get_resource_object(result)
-
-    def delete(self, resource_id, data=None):
-        path = self.get_resource_name() + "/" + str(resource_id)
-        return self.perform_api_call(self.REST_DELETE, path, data)
-
-    def list(self, **params):
-        path = self.get_resource_name()
-        result = self.perform_api_call(self.REST_LIST, path, params=params)
-        return ObjectList(result, self.get_resource_object({}).__class__, self.client)
 
     def perform_api_call(self, http_method, path, data=None, params=None):
         resp = self.client.perform_http_call(http_method, path, data, params)
@@ -79,3 +50,47 @@ class ResourceBase(object):
         if "embed" not in params:
             return
         return params["embed"].split(",")
+
+
+class ResourceCreateMixin:
+    REST_CREATE = "POST"
+
+    def create(self, data=None, **params):
+        path = self.get_resource_name()
+        result = self.perform_api_call(self.REST_CREATE, path, data, params)
+        return self.get_resource_object(result)
+
+
+class ResourceGetMixin:
+    REST_READ = "GET"
+
+    def get(self, resource_id, **params):
+        path = self.get_resource_name() + "/" + str(resource_id)
+        result = self.perform_api_call(self.REST_READ, path, params=params)
+        return self.get_resource_object(result)
+
+
+class ResourceListMixin:
+    REST_LIST = "GET"
+
+    def list(self, **params):
+        path = self.get_resource_name()
+        result = self.perform_api_call(self.REST_LIST, path, params=params)
+        return ObjectList(result, self.get_resource_object({}).__class__, self.client)
+
+
+class ResourceUpdateMixin:
+    REST_UPDATE = "PATCH"
+
+    def update(self, resource_id, data=None, **params):
+        path = self.get_resource_name() + "/" + str(resource_id)
+        result = self.perform_api_call(self.REST_UPDATE, path, data, params)
+        return self.get_resource_object(result)
+
+
+class ResourceDeleteMixin:
+    REST_DELETE = "DELETE"
+
+    def delete(self, resource_id, data=None):
+        path = self.get_resource_name() + "/" + str(resource_id)
+        return self.perform_api_call(self.REST_DELETE, path, data)

--- a/mollie/api/resources/base.py
+++ b/mollie/api/resources/base.py
@@ -36,14 +36,6 @@ class ResourceBase(object):
                 )
         return result
 
-    def from_url(self, url, data=None, params=None):
-        """Utility method to return an object from a full URL (such as from _links).
-
-        This method always does a GET request and returns a single Object.
-        """
-        result = self.perform_api_call(self.REST_READ, url, data, params)
-        return self.get_resource_object(result)
-
     @staticmethod
     def extract_embed(params):
         """Extract and parse the embed parameter from the request."""
@@ -67,6 +59,14 @@ class ResourceGetMixin:
     def get(self, resource_id, **params):
         path = self.get_resource_name() + "/" + str(resource_id)
         result = self.perform_api_call(self.REST_READ, path, params=params)
+        return self.get_resource_object(result)
+
+    def from_url(self, url, data=None, params=None):
+        """Utility method to return an object from a full URL (such as from _links).
+
+        This method always does a GET request and returns a single Object.
+        """
+        result = self.perform_api_call(self.REST_READ, url, data, params)
         return self.get_resource_object(result)
 
 

--- a/mollie/api/resources/captures.py
+++ b/mollie/api/resources/captures.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.capture import Capture
-from .base import ResourceBase
+from .base import ResourceBase, ResourceGetMixin, ResourceListMixin
 
 
-class Captures(ResourceBase):
+class Captures(ResourceBase, ResourceGetMixin, ResourceListMixin):
     RESOURCE_ID_PREFIX = "cpt_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/chargebacks.py
+++ b/mollie/api/resources/chargebacks.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.chargeback import Chargeback
-from .base import ResourceBase
+from .base import ResourceBase, ResourceGetMixin, ResourceListMixin
 
 
-class Chargebacks(ResourceBase):
+class Chargebacks(ResourceBase, ResourceGetMixin, ResourceListMixin):
     RESOURCE_ID_PREFIX = "chb_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/clients.py
+++ b/mollie/api/resources/clients.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.client import Client
-from .base import ResourceBase
+from .base import ResourceBase, ResourceGetMixin, ResourceListMixin
 
 
-class Clients(ResourceBase):
+class Clients(ResourceBase, ResourceListMixin, ResourceGetMixin):
     """Retrieve a list of Mollie merchants connected to your partner account (only for Mollie partners)."""
 
     RESOURCE_ID_PREFIX = "org_"

--- a/mollie/api/resources/customer_mandates.py
+++ b/mollie/api/resources/customer_mandates.py
@@ -1,16 +1,9 @@
 from ..error import IdentifierError
 from ..objects.mandate import Mandate
-from .base import (
-    ResourceBase,
-    ResourceCreateMixin,
-    ResourceDeleteMixin,
-    ResourceGetMixin,
-    ResourceListMixin,
-    ResourceUpdateMixin,
-)
+from .base import ResourceAllMethodsMixin, ResourceBase
 
 
-class CustomerMandates(ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin):
+class CustomerMandates(ResourceBase, ResourceAllMethodsMixin):
     RESOURCE_ID_PREFIX = "mdt_"
     customer_id = None
 

--- a/mollie/api/resources/customer_mandates.py
+++ b/mollie/api/resources/customer_mandates.py
@@ -1,9 +1,16 @@
 from ..error import IdentifierError
 from ..objects.mandate import Mandate
-from .base import ResourceBase
+from .base import (
+    ResourceBase,
+    ResourceCreateMixin,
+    ResourceDeleteMixin,
+    ResourceGetMixin,
+    ResourceListMixin,
+    ResourceUpdateMixin,
+)
 
 
-class CustomerMandates(ResourceBase):
+class CustomerMandates(ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin):
     RESOURCE_ID_PREFIX = "mdt_"
     customer_id = None
 

--- a/mollie/api/resources/customer_subscriptions.py
+++ b/mollie/api/resources/customer_subscriptions.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.subscription import Subscription
-from .base import ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin
+from .base import ResourceAllMethodsMixin, ResourceBase
 
 
-class CustomerSubscriptions(ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceListMixin, ResourceGetMixin, ResourceUpdateMixin):
+class CustomerSubscriptions(ResourceBase, ResourceAllMethodsMixin):
     RESOURCE_ID_PREFIX = "sub_"
     customer_id = None
 

--- a/mollie/api/resources/customer_subscriptions.py
+++ b/mollie/api/resources/customer_subscriptions.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.subscription import Subscription
-from .base import ResourceBase
+from .base import ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin
 
 
-class CustomerSubscriptions(ResourceBase):
+class CustomerSubscriptions(ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceListMixin, ResourceGetMixin, ResourceUpdateMixin):
     RESOURCE_ID_PREFIX = "sub_"
     customer_id = None
 

--- a/mollie/api/resources/customers.py
+++ b/mollie/api/resources/customers.py
@@ -1,16 +1,9 @@
 from ..error import IdentifierError
 from ..objects.customer import Customer
-from .base import (
-    ResourceBase,
-    ResourceCreateMixin,
-    ResourceDeleteMixin,
-    ResourceGetMixin,
-    ResourceListMixin,
-    ResourceUpdateMixin,
-)
+from .base import ResourceAllMethodsMixin, ResourceBase
 
 
-class Customers(ResourceBase, ResourceListMixin, ResourceCreateMixin, ResourceUpdateMixin, ResourceGetMixin, ResourceDeleteMixin):
+class Customers(ResourceBase, ResourceAllMethodsMixin):
     RESOURCE_ID_PREFIX = "cst_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/customers.py
+++ b/mollie/api/resources/customers.py
@@ -1,9 +1,16 @@
 from ..error import IdentifierError
 from ..objects.customer import Customer
-from .base import ResourceBase
+from .base import (
+    ResourceBase,
+    ResourceCreateMixin,
+    ResourceDeleteMixin,
+    ResourceGetMixin,
+    ResourceListMixin,
+    ResourceUpdateMixin,
+)
 
 
-class Customers(ResourceBase):
+class Customers(ResourceBase, ResourceListMixin, ResourceCreateMixin, ResourceUpdateMixin, ResourceGetMixin, ResourceDeleteMixin):
     RESOURCE_ID_PREFIX = "cst_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/invoices.py
+++ b/mollie/api/resources/invoices.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.invoice import Invoice
-from .base import ResourceBase
+from .base import ResourceBase, ResourceGetMixin, ResourceListMixin
 
 
-class Invoices(ResourceBase):
+class Invoices(ResourceBase, ResourceGetMixin, ResourceListMixin):
     RESOURCE_ID_PREFIX = "inv_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/methods.py
+++ b/mollie/api/resources/methods.py
@@ -1,9 +1,9 @@
 from ..objects.list import ObjectList
 from ..objects.method import Method
-from .base import ResourceBase
+from .base import ResourceBase, ResourceGetMixin, ResourceListMixin
 
 
-class Methods(ResourceBase):
+class Methods(ResourceBase, ResourceGetMixin, ResourceListMixin):
     def get_resource_object(self, result):
         return Method(result)
 

--- a/mollie/api/resources/onboarding.py
+++ b/mollie/api/resources/onboarding.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.onboarding import Onboarding as OnboardingObject
-from .base import ResourceBase
+from .base import ResourceBase, ResourceCreateMixin, ResourceGetMixin
 
 
-class Onboarding(ResourceBase):
+class Onboarding(ResourceBase, ResourceGetMixin):
     def get_resource_object(self, result):
         return OnboardingObject(result, self.client)
 
@@ -14,5 +14,5 @@ class Onboarding(ResourceBase):
 
     def create(self, resource_id, data=None, **params):
         path = self.get_resource_name() + "/" + str(resource_id)
-        result = self.perform_api_call(self.REST_CREATE, path, data, params)
+        result = self.perform_api_call(ResourceCreateMixin.REST_CREATE, path, data, params)
         return self.get_resource_object(result)

--- a/mollie/api/resources/order_lines.py
+++ b/mollie/api/resources/order_lines.py
@@ -1,6 +1,6 @@
 from ..error import DataConsistencyError
 from ..objects.order_line import OrderLine
-from .base import ResourceBase
+from .base import ResourceBase, ResourceDeleteMixin, ResourceUpdateMixin
 
 
 class OrderLines(ResourceBase):
@@ -27,7 +27,7 @@ class OrderLines(ResourceBase):
         with the orderline IDs and quantities in the request body.
         """
         path = self.get_resource_name()
-        result = self.perform_api_call(self.REST_DELETE, path, data=data)
+        result = self.perform_api_call(ResourceDeleteMixin.REST_DELETE, path, data=data)
         return result
 
     def update(self, resource_id, data=None, **params):
@@ -40,7 +40,7 @@ class OrderLines(ResourceBase):
         If you wish to retrieve the order object, you can do so by using the order_id property of the orderline.
         """
         path = self.get_resource_name() + "/" + str(resource_id)
-        result = self.perform_api_call(self.REST_UPDATE, path, data=data)
+        result = self.perform_api_call(ResourceUpdateMixin.REST_UPDATE, path, data=data)
 
         for line in result["lines"]:
             if line["id"] == resource_id:

--- a/mollie/api/resources/orders.py
+++ b/mollie/api/resources/orders.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.order import Order
-from .base import ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin
+from .base import ResourceAllMethodsMixin, ResourceBase
 
 
-class Orders(ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin):
+class Orders(ResourceBase, ResourceAllMethodsMixin):
     RESOURCE_ID_PREFIX = "ord_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/orders.py
+++ b/mollie/api/resources/orders.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.order import Order
-from .base import ResourceBase
+from .base import ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin
 
 
-class Orders(ResourceBase):
+class Orders(ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin):
     RESOURCE_ID_PREFIX = "ord_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/organizations.py
+++ b/mollie/api/resources/organizations.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.organization import Organization
-from .base import ResourceBase
+from .base import ResourceBase, ResourceGetMixin
 
 
-class Organizations(ResourceBase):
+class Organizations(ResourceBase, ResourceGetMixin):
     RESOURCE_ID_PREFIX = "org_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/payment_links.py
+++ b/mollie/api/resources/payment_links.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.payment_link import PaymentLink
-from .base import ResourceBase
+from .base import ResourceBase, ResourceCreateMixin, ResourceGetMixin, ResourceListMixin
 
 
-class PaymentLinks(ResourceBase):
+class PaymentLinks(ResourceBase, ResourceCreateMixin, ResourceGetMixin, ResourceListMixin):
     RESOURCE_ID_PREFIX = "pl_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/payments.py
+++ b/mollie/api/resources/payments.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.payment import Payment
-from .base import ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin
+from .base import ResourceAllMethodsMixin, ResourceBase
 
 
-class Payments(ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin):
+class Payments(ResourceBase, ResourceAllMethodsMixin):
     RESOURCE_ID_PREFIX = "tr_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/payments.py
+++ b/mollie/api/resources/payments.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.payment import Payment
-from .base import ResourceBase
+from .base import ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin
 
 
-class Payments(ResourceBase):
+class Payments(ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin):
     RESOURCE_ID_PREFIX = "tr_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/permissions.py
+++ b/mollie/api/resources/permissions.py
@@ -2,10 +2,10 @@ import re
 
 from ..error import IdentifierError
 from ..objects.permission import Permission
-from .base import ResourceBase
+from .base import ResourceBase, ResourceGetMixin, ResourceListMixin
 
 
-class Permissions(ResourceBase):
+class Permissions(ResourceBase, ResourceGetMixin, ResourceListMixin):
     def get_resource_object(self, result):
         return Permission(result, self.client)
 

--- a/mollie/api/resources/profile_methods.py
+++ b/mollie/api/resources/profile_methods.py
@@ -1,8 +1,9 @@
 from ..error import RequestError
+from .base import ResourceCreateMixin, ResourceDeleteMixin
 from .methods import Methods
 
 
-class ProfileMethods(Methods):
+class ProfileMethods(Methods, ResourceCreateMixin, ResourceDeleteMixin):
     RESOURCE_REQUIRED_METHODS = ["giftcard", "voucher"]
 
     profile_id = None
@@ -29,9 +30,8 @@ class ProfileMethods(Methods):
         if self.method_id in self.RESOURCE_REQUIRED_METHODS and resource_id is None:
             raise RequestError(f"resource_id is required when enabling a {self.method_id}.")
         self.resource_id = resource_id
-        path = self.get_resource_name()
-        result = self.perform_api_call(self.REST_CREATE, path, data=data, params=params)
-        return self.get_resource_object(result)
+
+        return super().create(data, **params)
 
     def with_parent_id(self, profile_id, method=None):
         self.method_id = method

--- a/mollie/api/resources/profiles.py
+++ b/mollie/api/resources/profiles.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.profile import Profile
-from .base import ResourceBase
+from .base import ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin
 
 
-class Profiles(ResourceBase):
+class Profiles(ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin):
     RESOURCE_ID_PREFIX = "pfl_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/profiles.py
+++ b/mollie/api/resources/profiles.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.profile import Profile
-from .base import ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin
+from .base import ResourceAllMethodsMixin, ResourceBase
 
 
-class Profiles(ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin):
+class Profiles(ResourceBase, ResourceAllMethodsMixin):
     RESOURCE_ID_PREFIX = "pfl_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/refunds.py
+++ b/mollie/api/resources/refunds.py
@@ -1,9 +1,9 @@
 from ..error import IdentifierError
 from ..objects.refund import Refund
-from .base import ResourceBase
+from .base import ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin
 
 
-class Refunds(ResourceBase):
+class Refunds(ResourceBase, ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, ResourceListMixin):
     RESOURCE_ID_PREFIX = "re_"
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/settlements.py
+++ b/mollie/api/resources/settlements.py
@@ -2,10 +2,10 @@ import re
 
 from ..error import IdentifierError
 from ..objects.settlement import Settlement
-from .base import ResourceBase
+from .base import ResourceBase, ResourceGetMixin, ResourceListMixin
 
 
-class Settlements(ResourceBase):
+class Settlements(ResourceBase, ResourceGetMixin, ResourceListMixin):
     RESOURCE_ID_PREFIX = "stl_"
 
     # According to Mollie, the bank reference is formatted as:

--- a/mollie/api/resources/shipments.py
+++ b/mollie/api/resources/shipments.py
@@ -1,8 +1,8 @@
 from ..objects.shipment import Shipment
-from .base import ResourceBase
+from .base import ResourceBase, ResourceCreateMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin
 
 
-class Shipments(ResourceBase):
+class Shipments(ResourceBase, ResourceCreateMixin, ResourceGetMixin, ResourceListMixin, ResourceUpdateMixin):
     order_id = None
 
     def get_resource_object(self, result):

--- a/mollie/api/resources/subscriptions.py
+++ b/mollie/api/resources/subscriptions.py
@@ -1,19 +1,7 @@
 from ..objects.subscription import Subscription
-from .base import ResourceBase
+from .base import ResourceBase, ResourceListMixin
 
 
-class Subscriptions(ResourceBase):
+class Subscriptions(ResourceBase, ResourceListMixin):
     def get_resource_object(self, result):
         return Subscription(result, self.client)
-
-    def create(self, data=None, **params):
-        raise NotImplementedError('The endpoint "create" is not supported.')
-
-    def get(self, resource_id, **params):
-        raise NotImplementedError('The endpoint "get" is not supported.')
-
-    def update(self, resource_id, data=None, **params):
-        raise NotImplementedError('The endpoint "update" is not supported.')
-
-    def delete(self, resource_id, data=None):
-        raise NotImplementedError('The endpoint "delete" is not supported.')

--- a/tests/test_payment_captures.py
+++ b/tests/test_payment_captures.py
@@ -18,7 +18,7 @@ def test_capture_resource_class(client, response):
     assert isinstance(Capture.get_resource_class(client), Captures)
 
 
-def test_get_payment_captures_by_payment_id(client, response):
+def test_list_payment_captures_by_payment_id(client, response):
     """Get capture relevant to payment by payment id."""
     response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/captures", "captures_list")
 

--- a/tests/test_payment_chargebacks.py
+++ b/tests/test_payment_chargebacks.py
@@ -9,7 +9,7 @@ CHARGEBACK_ID = "chb_n9z0tp"
 SETTLEMENT_ID = "stl_jDk30akdN"
 
 
-def test_get_payment_chargebacks_by_payment_id(client, response):
+def test_list_payment_chargebacks_by_payment_id(client, response):
     """Get chargebacks relevant to payment by payment id."""
     response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/chargebacks", "chargebacks_list")
 

--- a/tests/test_settlement_captures.py
+++ b/tests/test_settlement_captures.py
@@ -4,10 +4,9 @@ from .utils import assert_list_object
 
 PAYMENT_ID = "tr_7UhSN1zuXS"
 SETTLEMENT_ID = "stl_jDk30akdN"
-CHARGEBACK_ID = "chb_n9z0tp"
 
 
-def test_get_settlement_captures_by_capture_id(oauth_client, response):
+def test_list_settlement_captures_by_capture_id(oauth_client, response):
     """Get captures relevant to settlement by settlement id."""
     response.get(f"https://api.mollie.com/v2/settlements/{SETTLEMENT_ID}/captures", "captures_list")
 

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -1,5 +1,3 @@
-import pytest
-
 from mollie.api.objects.subscription import Subscription
 
 from .utils import assert_list_object
@@ -11,23 +9,3 @@ def test_list_customers(client, response):
 
     subscriptions = client.subscriptions.list()
     assert_list_object(subscriptions, Subscription)
-
-
-def test_create_subscription(client):
-    with pytest.raises(NotImplementedError, match='The endpoint "create" is not supported.'):
-        client.subscriptions.create()
-
-
-def test_get_subscription(client):
-    with pytest.raises(NotImplementedError, match='The endpoint "get" is not supported.'):
-        client.subscriptions.get("sub_rVKGtNd6s3")
-
-
-def test_update_subscription(client):
-    with pytest.raises(NotImplementedError, match='The endpoint "update" is not supported.'):
-        client.subscriptions.update("sub_rVKGtNd6s3")
-
-
-def test_delete_subscription(client):
-    with pytest.raises(NotImplementedError, match='The endpoint "delete" is not supported.'):
-        client.subscriptions.delete("sub_rVKGtNd6s3")


### PR DESCRIPTION
Currently, all resources in the client have all API manipulation methods (`.list()`, `.get()`, `.create()`, `.delete()`, `.update()`), but many resources only support a subset of these (f.i. [chargebacks are read-only](https://docs.mollie.com/reference/v2/chargebacks-api/overview) but the client has a `.create()` for chargebacks that always will result in an error.

This PR corrects this, and removes resource methods from resources that aren't supported, leaving only the supported methods in place.

Related to #255

