### PR TITLE
Update docs and release scheme to use the python versioning scheme.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,9 +82,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}  # Provided by github actions, no need to configure
           tag: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           body: |
             Summary:
               - TODO
+
+            Install it: https://pypi.org/project/mollie-api-python/${{ github.ref_name }}
           draft: true
           artifacts: dist/*

--- a/release_process.md
+++ b/release_process.md
@@ -3,6 +3,6 @@ To create a release there are a few steps you should follow:
 - We use [Semantic Versioning](https://semver.org/). If you're going to release a breaking change or a major new feature, do a minor version bump (x.y.z => x.y+1.z). Otherwise, do a patch version bump (x.y.z => x.y.z+1).
 - If you decide to do a minor version change, handle deprecations. See (Pending)DeprecationWarning subclasses in `error.py`.
 - Update the version number in `version.py` and push this to master.
-- Create a new tag with the new version number in the following way: `git tag v<major.minor.patch>`.
+- Create a new tag with the new version number in the following way: `git tag <major.minor.patch>`.
 - Push the tag by using `git push --tags`.
 - The build process will create a package on PYPI and a draft release on [GitHub](https://github.com/mollie/mollie-api-python/releases/). Edit the draft release, type a summary of all changes and remove the draft status.


### PR DESCRIPTION
From now on, we should use the Python versioning scheme to tag releases, e.g. no longer use `v3.0.0` but just `3.0.0`.

I'll tag all 3.x releases in retrospect with these versions.