### PR TITLE
Enable mypy 'check_untyped_defs'

### DIFF
--- a/mollie/api/objects/balance_report.py
+++ b/mollie/api/objects/balance_report.py
@@ -1,12 +1,19 @@
+from typing import TYPE_CHECKING, Any
+
 from .base import ObjectBase
+
+if TYPE_CHECKING:
+    from ..client import Client
+    from ..resources import BalanceReports
 
 
 class BalanceReport(ObjectBase):
     @classmethod
-    def get_resource_class(cls, client):
+    def get_resource_class(cls, client: "Client", **kwargs: Any) -> "BalanceReports":
         from ..resources import BalanceReports
 
-        return BalanceReports(client)
+        balance = kwargs["balance"]
+        return BalanceReports(client, balance)
 
     @property
     def resource(self):

--- a/mollie/api/objects/balance_transaction.py
+++ b/mollie/api/objects/balance_transaction.py
@@ -1,12 +1,19 @@
+from typing import TYPE_CHECKING, Any
+
 from .base import ObjectBase
+
+if TYPE_CHECKING:
+    from ..client import Client
+    from ..resources import BalanceTransactions
 
 
 class BalanceTransaction(ObjectBase):
     @classmethod
-    def get_resource_class(cls, client):
+    def get_resource_class(cls, client: "Client", **kwargs: Any) -> "BalanceTransactions":
         from ..resources import BalanceTransactions
 
-        return BalanceTransactions(client)
+        balance = kwargs["balance"]
+        return BalanceTransactions(client, balance)
 
     @classmethod
     def get_object_name(cls):

--- a/mollie/api/objects/base.py
+++ b/mollie/api/objects/base.py
@@ -1,4 +1,9 @@
+from typing import TYPE_CHECKING, Any
+
 from ..error import EmbedNotFound
+
+if TYPE_CHECKING:
+    from ..client import Client
 
 
 class ObjectBase(dict):
@@ -42,5 +47,5 @@ class ObjectBase(dict):
         return f"{name}s"
 
     @classmethod
-    def get_resource_class(cls, client):
+    def get_resource_class(cls, client: "Client", **kwargs: Any) -> Any:
         raise NotImplementedError  # pragma: no cover

--- a/mollie/api/objects/capture.py
+++ b/mollie/api/objects/capture.py
@@ -1,12 +1,19 @@
+from typing import TYPE_CHECKING, Any
+
 from .base import ObjectBase
+
+if TYPE_CHECKING:
+    from ..client import Client
+    from ..resources import PaymentCaptures
 
 
 class Capture(ObjectBase):
     @classmethod
-    def get_resource_class(cls, client):
+    def get_resource_class(cls, client: "Client", **kwargs: Any) -> "PaymentCaptures":
         from ..resources import PaymentCaptures
 
-        return PaymentCaptures(client)
+        payment = kwargs["payment"]
+        return PaymentCaptures(client, payment)
 
     @property
     def id(self):
@@ -50,9 +57,10 @@ class Capture(ObjectBase):
         url = self._get_link("shipment")
         if url:
             from ..resources import OrderShipments
+            from .order import Order
 
-            # We fake the order object here, since it is not used by from_url()
-            return OrderShipments(self.client, order=None).from_url(url)
+            order = Order({}, self.client)
+            return OrderShipments(self.client, order).from_url(url)
 
     def get_settlement(self):
         """Return the settlement for this capture."""

--- a/mollie/api/objects/mandate.py
+++ b/mollie/api/objects/mandate.py
@@ -1,12 +1,19 @@
+from typing import TYPE_CHECKING, Any
+
 from .base import ObjectBase
+
+if TYPE_CHECKING:
+    from ..client import Client
+    from ..resources import CustomerMandates
 
 
 class Mandate(ObjectBase):
     @classmethod
-    def get_resource_class(cls, client):
+    def get_resource_class(cls, client: "Client", **kwargs: Any) -> "CustomerMandates":
         from ..resources import CustomerMandates
 
-        return CustomerMandates(client)
+        customer = kwargs["customer"]
+        return CustomerMandates(client, customer)
 
     STATUS_PENDING = "pending"
     STATUS_VALID = "valid"

--- a/mollie/api/objects/order_line.py
+++ b/mollie/api/objects/order_line.py
@@ -1,12 +1,19 @@
+from typing import TYPE_CHECKING, Any
+
 from .base import ObjectBase
+
+if TYPE_CHECKING:
+    from ..client import Client
+    from ..resources import OrderLines
 
 
 class OrderLine(ObjectBase):
     @classmethod
-    def get_resource_class(cls, client):
+    def get_resource_class(cls, client: "Client", **kwargs: Any) -> "OrderLines":
         from ..resources import OrderLines
 
-        return OrderLines(client)
+        order = kwargs["order"]
+        return OrderLines(client, order)
 
     STATUS_CREATED = "created"
     STATUS_AUTHORIZED = "authorized"

--- a/mollie/api/objects/payment.py
+++ b/mollie/api/objects/payment.py
@@ -224,7 +224,8 @@ class Payment(ObjectBase):
         if url:
             from ..resources import CustomerSubscriptions
 
-            return CustomerSubscriptions(self.client, customer=None).from_url(url)
+            customer = Customer({}, self.client)
+            return CustomerSubscriptions(self.client, customer).from_url(url)
 
     def get_customer(self):
         """Return the customer for this payment."""

--- a/mollie/api/objects/subscription.py
+++ b/mollie/api/objects/subscription.py
@@ -6,10 +6,11 @@ from .customer import Customer
 
 class Subscription(ObjectBase):
     @classmethod
-    def get_resource_class(cls, client):
+    def get_resource_class(cls, client, **kwargs):
         from ..resources import CustomerSubscriptions
 
-        return CustomerSubscriptions(client)
+        customer = kwargs["customer"]
+        return CustomerSubscriptions(client, customer)
 
     STATUS_ACTIVE = "active"
     STATUS_PENDING = "pending"  # Waiting for a valid mandate.

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,6 +6,7 @@ no_implicit_optional = True
 strict_equality = True
 strict_concatenate = True
 disallow_incomplete_defs = True
+check_untyped_defs = True
 
 [mypy-requests_oauthlib.*]
 # requests-oauthlib-1.3.1 has no types yet, but: https://github.com/requests/requests-oauthlib/issues/428


### PR DESCRIPTION
This uncovers various issues with the implementation of `get_resource_class()`. Now we have mypy passing and the code should work in theory, but the only place where this method is used (in `ObjectList`), already shows clearly that the current approach won't work.

We need to rethink the way ObjectList works, and hopefully get rid of `get_resource_class()` entirely.

For now: the code stays the same, but with working type annotations.