### PR TITLE
Remove incorrect type annotation from **kwargs

### DIFF
--- a/mollie/api/resources/base.py
+++ b/mollie/api/resources/base.py
@@ -73,14 +73,14 @@ class ResourceBase:
 
 
 class ResourceCreateMixin(ResourceBase):
-    def create(self, data: Optional[Dict[str, Any]] = None, **params: Optional[Dict[str, Any]]) -> Any:
+    def create(self, data: Optional[Dict[str, Any]] = None, **params: Any) -> Any:
         path = self.get_resource_path()
         result = self.perform_api_call(self.REST_CREATE, path, data, params)
         return self.get_resource_object(result)
 
 
 class ResourceGetMixin(ResourceBase):
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> Any:
+    def get(self, resource_id: str, **params: Any) -> Any:
         resource_path = self.get_resource_path()
         path = f"{resource_path}/{resource_id}"
         result = self.perform_api_call(self.REST_READ, path, params=params)
@@ -96,16 +96,14 @@ class ResourceGetMixin(ResourceBase):
 
 
 class ResourceListMixin(ResourceBase):
-    def list(self, **params: Optional[Dict[str, Any]]) -> ObjectList:
+    def list(self, **params: Any) -> ObjectList:
         path = self.get_resource_path()
         result = self.perform_api_call(self.REST_LIST, path, params=params)
         return ObjectList(result, self.get_resource_object({}).__class__, self.client)
 
 
 class ResourceUpdateMixin(ResourceBase):
-    def update(
-        self, resource_id: str, data: Optional[Dict[str, Any]] = None, **params: Optional[Dict[str, Any]]
-    ) -> Any:
+    def update(self, resource_id: str, data: Optional[Dict[str, Any]] = None, **params: Any) -> Any:
         resource_path = self.get_resource_path()
         path = f"{resource_path}/{resource_id}"
         result = self.perform_api_call(self.REST_UPDATE, path, data, params)
@@ -113,7 +111,7 @@ class ResourceUpdateMixin(ResourceBase):
 
 
 class ResourceDeleteMixin(ResourceBase):
-    def delete(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> Any:
+    def delete(self, resource_id: str, **params: Any) -> Any:
         resource_path = self.get_resource_path()
         path = f"{resource_path}/{resource_id}"
         return self.perform_api_call(self.REST_DELETE, path, params=params)

--- a/mollie/api/resources/captures.py
+++ b/mollie/api/resources/captures.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any
 
 from ..objects.capture import Capture
 from .base import ResourceBase, ResourceGetMixin, ResourceListMixin
@@ -33,7 +33,7 @@ class PaymentCaptures(CapturesBase, ResourceGetMixin, ResourceListMixin):
     def get_resource_path(self) -> str:
         return f"payments/{self._payment.id}/captures"
 
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> Capture:
+    def get(self, resource_id: str, **params: Any) -> Capture:
         self.validate_resource_id(resource_id, "capture ID")
         return super().get(resource_id, **params)
 

--- a/mollie/api/resources/chargebacks.py
+++ b/mollie/api/resources/chargebacks.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any
 
 from ..objects.chargeback import Chargeback
 from ..objects.list import ObjectList
@@ -43,7 +43,7 @@ class PaymentChargebacks(ChargebacksBase, ResourceGetMixin, ResourceListMixin):
     def get_resource_path(self) -> str:
         return f"payments/{self._payment.id}/chargebacks"
 
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> Chargeback:
+    def get(self, resource_id: str, **params: Any) -> Chargeback:
         self.validate_resource_id(resource_id, "chargeback ID")
         return super().get(resource_id, **params)
 
@@ -74,7 +74,7 @@ class ProfileChargebacks(ChargebacksBase):
         self._profile = profile
         super().__init__(client)
 
-    def list(self, **params: Optional[Dict[str, Any]]) -> ObjectList:
+    def list(self, **params: Any) -> ObjectList:
         # Set the profileId in the query params
         params.update({"profileId": self._profile.id})
         return Chargebacks(self.client).list(**params)

--- a/mollie/api/resources/clients.py
+++ b/mollie/api/resources/clients.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any
 
 from ..objects.client import Client
 from .base import ResourceGetMixin, ResourceListMixin
@@ -20,7 +20,7 @@ class Clients(ResourceListMixin, ResourceGetMixin):
     def get_resource_object(self, result: dict) -> Client:
         return Client(result, self.client)
 
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> Client:
+    def get(self, resource_id: str, **params: Any) -> Client:
         """Retrieve a single client, linked to your partner account, by its ID."""
         self.validate_resource_id(resource_id, "client ID")
         return super().get(resource_id, **params)

--- a/mollie/api/resources/customers.py
+++ b/mollie/api/resources/customers.py
@@ -12,16 +12,14 @@ class Customers(ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, Reso
     def get_resource_object(self, result: dict) -> Customer:
         return Customer(result, self.client)
 
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> Customer:
+    def get(self, resource_id: str, **params: Any) -> Customer:
         self.validate_resource_id(resource_id, "customer ID")
         return super().get(resource_id, **params)
 
-    def update(
-        self, resource_id: str, data: Optional[Dict[str, Any]] = None, **params: Optional[Dict[str, Any]]
-    ) -> Customer:
+    def update(self, resource_id: str, data: Optional[Dict[str, Any]] = None, **params: Any) -> Customer:
         self.validate_resource_id(resource_id, "customer ID")
         return super().update(resource_id, data, **params)
 
-    def delete(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> dict:
+    def delete(self, resource_id: str, **params: Any) -> dict:
         self.validate_resource_id(resource_id, "customer ID")
         return super().delete(resource_id, **params)

--- a/mollie/api/resources/invoices.py
+++ b/mollie/api/resources/invoices.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any
 
 from ..objects.invoice import Invoice
 from .base import ResourceGetMixin, ResourceListMixin
@@ -16,6 +16,6 @@ class Invoices(ResourceGetMixin, ResourceListMixin):
     def get_resource_object(self, result: dict) -> Invoice:
         return Invoice(result, self.client)
 
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> Invoice:
+    def get(self, resource_id: str, **params: Any) -> Invoice:
         self.validate_resource_id(resource_id, "invoice ID")
         return super().get(resource_id, **params)

--- a/mollie/api/resources/mandates.py
+++ b/mollie/api/resources/mandates.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any
 
 from ..objects.customer import Customer
 from ..objects.mandate import Mandate
@@ -30,10 +30,10 @@ class CustomerMandates(ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixi
     def get_resource_object(self, result: dict) -> Mandate:
         return Mandate(result, self.client)
 
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> Mandate:
+    def get(self, resource_id: str, **params: Any) -> Mandate:
         self.validate_resource_id(resource_id, "mandate ID")
         return super().get(resource_id, **params)
 
-    def delete(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> dict:
+    def delete(self, resource_id: str, **params: Any) -> dict:
         self.validate_resource_id(resource_id, "mandate ID")
         return super().delete(resource_id, **params)

--- a/mollie/api/resources/methods.py
+++ b/mollie/api/resources/methods.py
@@ -25,7 +25,7 @@ class MethodsBase(ResourceBase):
 class Methods(MethodsBase, ResourceGetMixin, ResourceListMixin):
     """Resource handler for the `/methods` endpoint."""
 
-    def all(self, **params: Optional[Dict[str, Any]]) -> ObjectList:
+    def all(self, **params: Any) -> ObjectList:
         """List all mollie payment methods, including methods that aren't activated in your profile."""
         resource_path = self.get_resource_path()
         path = f"{resource_path}/all"
@@ -53,7 +53,7 @@ class ProfileMethods(MethodsBase):
             Method.VOUCHER,
         ]
 
-    def enable(self, method_id: str, **params: Optional[Dict[str, Any]]) -> Method:
+    def enable(self, method_id: str, **params: Any) -> Method:
         """
         Enable payment method for profile.
 
@@ -70,7 +70,7 @@ class ProfileMethods(MethodsBase):
         result = self.perform_api_call(self.REST_CREATE, path, params=params)
         return self.get_resource_object(result)
 
-    def disable(self, method_id: str, **params: Optional[Dict[str, Any]]) -> Method:
+    def disable(self, method_id: str, **params: Any) -> Method:
         """
         Disable payment method for the profile.
 
@@ -87,14 +87,14 @@ class ProfileMethods(MethodsBase):
         result = self.perform_api_call(self.REST_DELETE, path, params=params)
         return self.get_resource_object(result)
 
-    def list(self, **params: Optional[Dict[str, Any]]) -> ObjectList:
+    def list(self, **params: Any) -> ObjectList:
         """List the payment methods for the profile."""
         params.update({"profileId": self._profile.id})
         # Divert the API call to the general Methods resource
         return Methods(self.client).list(**params)
 
     def enable_issuer(
-        self, method_id: str, issuer_id: str, data: Optional[Dict[str, Any]] = None, **params: Optional[Dict[str, Any]]
+        self, method_id: str, issuer_id: str, data: Optional[Dict[str, Any]] = None, **params: Any
     ) -> Issuer:
         """
         Enable an issuer for a payment method.
@@ -115,7 +115,7 @@ class ProfileMethods(MethodsBase):
         result = self.perform_api_call(self.REST_CREATE, path, data, params)
         return Issuer(result, self.client)
 
-    def disable_issuer(self, method_id: str, issuer_id: str, **params: Optional[Dict[str, Any]]) -> Issuer:
+    def disable_issuer(self, method_id: str, issuer_id: str, **params: Any) -> Issuer:
         """
         Disable an issuer for a payment method.
 

--- a/mollie/api/resources/onboarding.py
+++ b/mollie/api/resources/onboarding.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from ..error import IdentifierError
 from ..objects.onboarding import Onboarding as OnboardingObject
@@ -15,12 +15,12 @@ class Onboarding(ResourceGetMixin):
     def get_resource_object(self, result: dict) -> OnboardingObject:
         return OnboardingObject(result, self.client)
 
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> OnboardingObject:
+    def get(self, resource_id: str, **params: Any) -> OnboardingObject:
         if resource_id != "me":
             raise IdentifierError(f"Invalid onboarding ID: '{resource_id}'. The onboarding ID should be 'me'.")
         return super().get(resource_id, **params)
 
-    def create(self, data: Dict[str, Any], **params: Optional[Dict[str, Any]]) -> OnboardingObject:
+    def create(self, data: Dict[str, Any], **params: Any) -> OnboardingObject:
         resource_path = self.get_resource_path()
         path = f"{resource_path}/me"
         result = self.perform_api_call(self.REST_CREATE, path, data, params)

--- a/mollie/api/resources/order_lines.py
+++ b/mollie/api/resources/order_lines.py
@@ -38,7 +38,7 @@ class OrderLines(ResourceBase):
     def get_resource_object(self, result: dict) -> OrderLine:
         return OrderLine(result, self.client)
 
-    def delete_lines(self, data: Optional[Dict[str, Any]] = None, **params: Optional[Dict[str, Any]]) -> dict:
+    def delete_lines(self, data: Optional[Dict[str, Any]] = None, **params: Any) -> dict:
         """
         Cancel multiple orderlines.
 
@@ -69,7 +69,7 @@ class OrderLines(ResourceBase):
         path = self.get_resource_path()
         return self.perform_api_call(self.REST_DELETE, path, data=data, params=params)
 
-    def delete(self, order_line_id: str, **params: Optional[Dict[str, Any]]) -> dict:
+    def delete(self, order_line_id: str, **params: Any) -> dict:
         """
         Cancel a single orderline.
 
@@ -83,9 +83,7 @@ class OrderLines(ResourceBase):
         }
         return self.delete_lines(data, **params)
 
-    def update(
-        self, order_line_id: str, data: Optional[Dict[str, Any]] = None, **params: Optional[Dict[str, Any]]
-    ) -> OrderLine:
+    def update(self, order_line_id: str, data: Optional[Dict[str, Any]] = None, **params: Any) -> OrderLine:
         """
         Custom handling for updating orderlines.
 
@@ -104,7 +102,7 @@ class OrderLines(ResourceBase):
 
         raise DataConsistencyError(f"OrderLine with id '{order_line_id}' not found in response.")
 
-    def list(self, **params: Optional[Dict[str, Any]]) -> ObjectList:
+    def list(self, **params: Any) -> ObjectList:
         """Return the orderline data from the related order."""
         lines = self._order._get_property("lines") or []
         data = {

--- a/mollie/api/resources/orders.py
+++ b/mollie/api/resources/orders.py
@@ -16,11 +16,11 @@ class Orders(ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, Resourc
     def get_resource_object(self, result: dict) -> Order:
         return Order(result, self.client)
 
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> Order:
+    def get(self, resource_id: str, **params: Any) -> Order:
         self.validate_resource_id(resource_id, "order ID")
         return super().get(resource_id, **params)
 
-    def delete(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> dict:
+    def delete(self, resource_id: str, **params: Any) -> dict:
         """Cancel order and return the order object.
 
         Deleting an order causes the order status to change to canceled.
@@ -30,9 +30,7 @@ class Orders(ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, Resourc
         result = super().delete(resource_id, **params)
         return self.get_resource_object(result)
 
-    def update(
-        self, resource_id: str, data: Optional[Dict[str, Any]] = None, **params: Optional[Dict[str, Any]]
-    ) -> Order:
+    def update(self, resource_id: str, data: Optional[Dict[str, Any]] = None, **params: Any) -> Order:
         """Update an order, and return the updated order."""
         self.validate_resource_id(resource_id, "order ID")
         return super().update(resource_id, data, **params)

--- a/mollie/api/resources/organizations.py
+++ b/mollie/api/resources/organizations.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any
 
 from ..objects.organization import Organization
 from .base import ResourceGetMixin
@@ -16,7 +16,7 @@ class Organizations(ResourceGetMixin):
     def get_resource_object(self, result: dict) -> Organization:
         return Organization(result, self.client)
 
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> Organization:
+    def get(self, resource_id: str, **params: Any) -> Organization:
         if resource_id != "me":
             self.validate_resource_id(resource_id, "organization ID")
         return super().get(resource_id, **params)

--- a/mollie/api/resources/payment_links.py
+++ b/mollie/api/resources/payment_links.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any
 
 from ..objects.payment_link import PaymentLink
 from .base import ResourceCreateMixin, ResourceGetMixin, ResourceListMixin
@@ -19,6 +19,6 @@ class PaymentLinks(ResourceCreateMixin, ResourceGetMixin, ResourceListMixin):
     def get_resource_object(self, result: dict) -> PaymentLink:
         return PaymentLink(result, self.client)
 
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> PaymentLink:
+    def get(self, resource_id: str, **params: Any) -> PaymentLink:
         self.validate_resource_id(resource_id, "payment link ID")
         return super().get(resource_id, **params)

--- a/mollie/api/resources/payments.py
+++ b/mollie/api/resources/payments.py
@@ -43,11 +43,11 @@ class Payments(
 ):
     """Resource handler for the `/payments` endpoint."""
 
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> Payment:
+    def get(self, resource_id: str, **params: Any) -> Payment:
         self.validate_resource_id(resource_id, "payment ID")
         return super().get(resource_id, **params)
 
-    def delete(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> dict:
+    def delete(self, resource_id: str, **params: Any) -> dict:
         """Cancel payment and return the payment object.
 
         Deleting a payment causes the payment status to change to canceled.
@@ -57,9 +57,7 @@ class Payments(
         result = super().delete(resource_id, **params)
         return self.get_resource_object(result)
 
-    def update(
-        self, resource_id: str, data: Optional[Dict[str, Any]] = None, **params: Optional[Dict[str, Any]]
-    ) -> Payment:
+    def update(self, resource_id: str, data: Optional[Dict[str, Any]] = None, **params: Any) -> Payment:
         self.validate_resource_id(resource_id, "payment ID")
         return super().update(resource_id, data, **params)
 
@@ -147,7 +145,7 @@ class ProfilePayments(PaymentsBase):
         self._profile = profile
         super().__init__(client)
 
-    def list(self, **params: Optional[Dict[str, Any]]) -> ObjectList:
+    def list(self, **params: Any) -> ObjectList:
         # Set the profileId in the query params
         params.update({"profileId": self._profile.id})
         return Payments(self.client).list(**params)

--- a/mollie/api/resources/permissions.py
+++ b/mollie/api/resources/permissions.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, Optional
+from typing import Any
 
 from ..error import IdentifierError
 from ..objects.permission import Permission
@@ -21,6 +21,6 @@ class Permissions(ResourceGetMixin, ResourceListMixin):
         if not permission_id or not bool(re.match(r"^[a-z]+\.[a-z]+$", permission_id)):
             raise IdentifierError(f"Invalid permission ID: '{permission_id}'. Does not match ^[a-z]+.[a-z]+$")
 
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> Permission:
+    def get(self, resource_id: str, **params: Any) -> Permission:
         self.validate_resource_id(resource_id)
         return super().get(resource_id, **params)

--- a/mollie/api/resources/profiles.py
+++ b/mollie/api/resources/profiles.py
@@ -16,17 +16,15 @@ class Profiles(ResourceCreateMixin, ResourceDeleteMixin, ResourceGetMixin, Resou
     def get_resource_object(self, result: dict) -> Profile:
         return Profile(result, self.client)
 
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> Profile:
+    def get(self, resource_id: str, **params: Any) -> Profile:
         if resource_id != "me":
             self.validate_resource_id(resource_id, "profile ID")
         return super().get(resource_id, **params)
 
-    def delete(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> dict:
+    def delete(self, resource_id: str, **params: Any) -> dict:
         self.validate_resource_id(resource_id, "profile ID")
         return super().delete(resource_id, **params)
 
-    def update(
-        self, resource_id: str, data: Optional[Dict[str, Any]] = None, **params: Optional[Dict[str, Any]]
-    ) -> Profile:
+    def update(self, resource_id: str, data: Optional[Dict[str, Any]] = None, **params: Any) -> Profile:
         self.validate_resource_id(resource_id, "profile ID")
         return super().update(resource_id, **params)

--- a/mollie/api/resources/refunds.py
+++ b/mollie/api/resources/refunds.py
@@ -45,11 +45,11 @@ class PaymentRefunds(RefundsBase, ResourceCreateMixin, ResourceDeleteMixin, Reso
     def get_resource_path(self) -> str:
         return f"payments/{self._payment.id}/refunds"
 
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> Refund:
+    def get(self, resource_id: str, **params: Any) -> Refund:
         self.validate_resource_id(resource_id, "Refund ID")
         return super().get(resource_id, **params)
 
-    def delete(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> dict:
+    def delete(self, resource_id: str, **params: Any) -> dict:
         self.validate_resource_id(resource_id, "Refund ID")
         return super().delete(resource_id, **params)
 
@@ -66,7 +66,7 @@ class OrderRefunds(RefundsBase, ResourceCreateMixin, ResourceListMixin):
     def get_resource_path(self) -> str:
         return f"orders/{self._order.id}/refunds"
 
-    def create(self, data: Optional[Dict[str, Any]] = None, **params: Optional[Dict[str, Any]]) -> Refund:
+    def create(self, data: Optional[Dict[str, Any]] = None, **params: Any) -> Refund:
         """Create a refund for the order. When no data arg is given, a refund for all order lines is assumed."""
         if not data:
             data = {"lines": []}
@@ -99,7 +99,7 @@ class ProfileRefunds(RefundsBase):
         self._profile = profile
         super().__init__(client)
 
-    def list(self, **params: Optional[Dict[str, Any]]) -> ObjectList:
+    def list(self, **params: Any) -> ObjectList:
         # Set the profileId in the query params
         params.update({"profileId": self._profile.id})
         return Refunds(self.client).list(**params)

--- a/mollie/api/resources/settlements.py
+++ b/mollie/api/resources/settlements.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, Optional, Pattern
+from typing import Any, Pattern
 
 from ..error import IdentifierError
 from ..objects.settlement import Settlement
@@ -49,6 +49,6 @@ class Settlements(ResourceGetMixin, ResourceListMixin):
             except IdentifierError:
                 raise IdentifierError(exc_message)
 
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> Settlement:
+    def get(self, resource_id: str, **params: Any) -> Settlement:
         self.validate_resource_id(resource_id)
         return super().get(resource_id, **params)

--- a/mollie/api/resources/shipments.py
+++ b/mollie/api/resources/shipments.py
@@ -29,7 +29,7 @@ class OrderShipments(ResourceCreateMixin, ResourceGetMixin, ResourceListMixin, R
     def get_resource_path(self) -> str:
         return f"orders/{self._order.id}/shipments"
 
-    def create(self, data: Optional[Dict[str, Any]] = None, **params: Optional[Dict[str, Any]]) -> Shipment:
+    def create(self, data: Optional[Dict[str, Any]] = None, **params: Any) -> Shipment:
         """Create a shipment for an order.
 
         If the data parameter is omitted, a shipment for all order lines is assumed.
@@ -38,12 +38,10 @@ class OrderShipments(ResourceCreateMixin, ResourceGetMixin, ResourceListMixin, R
             data = {"lines": []}
         return super().create(data, **params)
 
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> Shipment:
+    def get(self, resource_id: str, **params: Any) -> Shipment:
         self.validate_resource_id(resource_id, "shipment ID")
         return super().get(resource_id, **params)
 
-    def update(
-        self, resource_id: str, data: Optional[Dict[str, Any]] = None, **params: Optional[Dict[str, Any]]
-    ) -> Shipment:
+    def update(self, resource_id: str, data: Optional[Dict[str, Any]] = None, **params: Any) -> Shipment:
         self.validate_resource_id(resource_id, "shipment ID")
         return super().update(resource_id, data, **params)

--- a/mollie/api/resources/subscriptions.py
+++ b/mollie/api/resources/subscriptions.py
@@ -52,17 +52,15 @@ class CustomerSubscriptions(
     def get_resource_path(self) -> str:
         return f"customers/{self._customer.id}/subscriptions"
 
-    def get(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> Subscription:
+    def get(self, resource_id: str, **params: Any) -> Subscription:
         self.validate_resource_id(resource_id, "subscription ID")
         return super().get(resource_id, **params)
 
-    def update(
-        self, resource_id: str, data: Optional[Dict[str, Any]] = None, **params: Optional[Dict[str, Any]]
-    ) -> Subscription:
+    def update(self, resource_id: str, data: Optional[Dict[str, Any]] = None, **params: Any) -> Subscription:
         self.validate_resource_id(resource_id, "subscription ID")
         return super().update(resource_id, data, **params)
 
-    def delete(self, resource_id: str, **params: Optional[Dict[str, Any]]) -> dict:
+    def delete(self, resource_id: str, **params: Any) -> dict:
         self.validate_resource_id(resource_id, "subscription ID")
         resp = super().delete(resource_id, **params)
         return self.get_resource_object(resp)


### PR DESCRIPTION
`**kwargs` should be annotated using only the type of the `value` in a `keyword=value` keyword argument.

Typing this as f.i. `**kwargs: str` means that all provided argument values need to be strings, which we can't support: `.list(limit=47)` uses an int, and it is valid usage. This leaves us with `Any` for now.