### PR TITLE
Enable testmode globally

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.7", "pypy-3.8", "pypy-3.9"]
+        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.7", "pypy-3.9"]
+        coverage_fail_under: [90]
+        include:
+          # https://github.com/nedbat/coveragepy/issues/1515
+          # https://foss.heptapod.net/pypy/pypy/-/issues/3876
+          - python_version: "pypy-3.8"
+            coverage_fail_under: 0
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -27,7 +33,7 @@ jobs:
           python -m pip install -r test_requirements.txt
 
       - name: Run unittests
-        run: python -m pytest
+        run: python -m pytest --cov-fail-under=${{ matrix.coverage_fail_under }}
 
       - name: Verify dependencies
         run: python -m safety check

--- a/mollie/api/client.py
+++ b/mollie/api/client.py
@@ -53,6 +53,7 @@ class Client(object):
     client_id: str = ""
     client_secret: str = ""
     set_token: Callable[[dict], None]
+    testmode: bool = False
 
     @staticmethod
     def validate_api_endpoint(api_endpoint: str) -> str:
@@ -126,6 +127,9 @@ class Client(object):
     def set_timeout(self, timeout: Union[int, Tuple[int, int]]) -> None:
         self.timeout = timeout
 
+    def set_testmode(self, testmode: bool) -> None:
+        self.testmode = testmode
+
     def set_user_agent_component(self, key: str, value: str, sanitize: bool = True) -> None:
         """Add or replace new user-agent component strings.
 
@@ -166,6 +170,13 @@ class Client(object):
                 payload = json.dumps(data)
             except TypeError as err:
                 raise RequestSetupError(f"Error encoding data into JSON: {err}.")
+
+        if params is None:
+            params = {}
+        if self.testmode and "testmode" not in params:
+            if not (self.api_key.startswith("access_") or hasattr(self, "_oauth_client")):
+                raise RequestSetupError("Configuring testmode only works with access_token or OAuth authorization")
+            params["testmode"] = "true"
 
         querystring = generate_querystring(params)
         if querystring:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ mock_use_standalone_module = true
 addopts = """
     --cov mollie/
     --no-cov-on-fail
-    --cov-fail-under=80
+    --cov-fail-under=90
     --cov-report=term-missing
     --cov-branch
 """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,12 +66,12 @@ class ImprovedRequestsMock(responses.RequestsMock):
     def get(self, url, filename, status=200, **kwargs):
         """Setup a mock response for a GET request."""
         body = self._get_body(filename)
-        self.add(responses.GET, url, body=body, status=status, content_type="application/hal+json", **kwargs)
+        return self.add(responses.GET, url, body=body, status=status, content_type="application/hal+json", **kwargs)
 
     def post(self, url, filename, status=200, **kwargs):
         """Setup a mock response for a POST request."""
         body = self._get_body(filename)
-        self.add(responses.POST, url, body=body, status=status, content_type="application/hal+json", **kwargs)
+        return self.add(responses.POST, url, body=body, status=status, content_type="application/hal+json", **kwargs)
 
     def delete(self, url, filename, status=204, **kwargs):
         """Setup a mock response for a DELETE request."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from mollie.api.client import Client
 logger = logging.getLogger("mollie.pytest.fixtures")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def client():
     """Setup a Mollie API client object."""
     api_key = os.environ.get("MOLLIE_API_KEY", "test_test")

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -302,7 +302,7 @@ def test_oauth_client_default_user_agent(oauth_client, response):
     # perform a request and inpect the actual used headers
     response.get("https://api.mollie.com/v2/organizations/me", "organization_current")
     oauth_client.organizations.get("me")
-    request = response.calls[0].request
+    request = response.calls[-1].request
     assert re.match(regex, request.headers["User-Agent"])
 
 

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -72,10 +72,8 @@ def test_client_no_api_key():
         client.customers.list()
 
 
-def test_client_invalid_api_key():
+def test_client_invalid_api_key(client):
     """Setting up an invalid api key raises an error."""
-    client = Client()
-
     with pytest.raises(RequestSetupError, match="Invalid API key: 'invalid'"):
         client.set_api_key("invalid")
 
@@ -108,13 +106,11 @@ def test_client_broken_cert_bundle(monkeypatch):
     assert "Could not find a suitable TLS CA certificate bundle, invalid path: /does/not/exist" in str(excinfo.value)
 
 
-def test_client_generic_request_error(response, oauth_client):
+def test_client_generic_request_error(client, response, oauth_client):
     """When the remote server refuses connections or other request issues arise, an error should be raised.
 
     The 'response' fixture blocks all outgoing connections, also when no actual responses are configured.
     """
-    client = Client()
-    client.set_api_key("test_test")
     client.set_api_endpoint("https://api.mollie.invalid/")
     with pytest.raises(RequestError, match="Unable to communicate with Mollie: Connection refused"):
         client.customers.list()
@@ -192,16 +188,14 @@ def test_client_delete_received_error_response(client, response, resp_payload, r
     assert excinfo.value.status == resp_status
 
 
-def test_client_response_404_but_no_payload(response):
+def test_client_response_404_but_no_payload(client, response):
     """An error response from the API should raise an error.
 
     When the response returns an error, but no valid error data is available in the response,
     we should still raise an error. The API v1 formatted error in the test is missing the required 'status' field.
     """
     response.get("https://api.mollie.com/v3/customers", "v1_api_error", status=404)
-    client = Client()
     client.api_version = "v3"
-    client.set_api_key("test_test")
 
     with pytest.raises(ResponseHandlingError, match="Invalid API version"):
         client.customers.list()
@@ -320,13 +314,12 @@ def test_client_user_agent_with_access_token():
     assert "OAuth/2.0" in client.user_agent
 
 
-def test_client_set_user_agent_component(response):
+def test_client_set_user_agent_component(client, response):
     """We should be able to add useragent components.
 
     Note: we don't use the fixture client because it is shared between tests, and we don't want it
     to be clobbered with random User-Agent strings.
     """
-    client = Client()
     assert "Hoeba" not in client.user_agent
     client.set_user_agent_component("Hoeba", "1.0.0")
     assert "Hoeba/1.0.0" in client.user_agent
@@ -348,9 +341,8 @@ def test_client_set_user_agent_component(response):
         ("trailing space ", "TrailingSpace"),
     ],
 )
-def test_client_set_user_agent_component_correct_key_syntax(key, expected):
+def test_client_set_user_agent_component_correct_key_syntax(client, key, expected):
     """When we receive UA component keys that don't adhere to the proposed syntax, they are corrected."""
-    client = Client()
     client.set_user_agent_component(key, "1.0.0")
     assert f"{expected}/1.0.0" in client.user_agent
 
@@ -367,16 +359,14 @@ def test_client_set_user_agent_component_correct_key_syntax(key, expected):
         ("trailing space ", "trailing_space"),
     ],
 )
-def test_client_set_user_agent_component_correct_value_syntax(value, expected):
+def test_client_set_user_agent_component_correct_value_syntax(client, value, expected):
     """When we receive UA component values that don't adhere to the proposed syntax, they are corrected."""
-    client = Client()
     client.set_user_agent_component("Something", value)
     assert f"Something/{expected}" in client.user_agent
 
 
-def test_client_update_user_agent_component():
+def test_client_update_user_agent_component(client):
     """We should be able to update the User-Agent component when using the same key."""
-    client = Client()
     client.set_user_agent_component("Test", "1.0.0")
     assert "Test/1.0.0" in client.user_agent
 

--- a/tests/test_payment_refunds.py
+++ b/tests/test_payment_refunds.py
@@ -63,39 +63,6 @@ def test_get_payment_refund_invalid_id(client, response):
     assert str(excinfo.value) == "Invalid Refund ID 'invalid', it should start with 're_'."
 
 
-@pytest.mark.skip(reason="Obsoleted by test_get_payment_refund")
-def test_get_refund(client, response):
-    """Retrieve a specific refund of a payment."""
-    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/refunds/{REFUND_ID}", "refund_single_no_links")
-    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
-
-    refund = client.payment_refunds.with_parent_id(PAYMENT_ID).get(REFUND_ID)
-    assert isinstance(refund, Refund)
-    # properties
-    assert refund.resource == "refund"
-    assert refund.id == REFUND_ID
-    assert refund.amount == {"currency": "EUR", "value": "5.95"}
-    assert refund.settlement_id is None
-    assert refund.settlement_amount is None
-    assert refund.description == "Required quantity not in stock, refunding one photo book."
-    assert refund.metadata == {"bookkeeping_id": 12345}
-    assert refund.status == Refund.STATUS_PENDING
-    assert_list_object(refund.lines, OrderLine)
-    assert refund.payment_id == PAYMENT_ID
-    assert refund.order_id is None
-    assert refund.created_at == "2018-03-14T17:09:02.0Z"
-    # properties from _links
-    assert refund.payment is not None
-    assert refund.settlement is None
-    assert refund.order is None
-
-    # additional methods
-    assert refund.is_queued() is False
-    assert refund.is_pending() is True
-    assert refund.is_processing() is False
-    assert refund.is_refunded() is False
-
-
 def test_payment_refund_get_related_payment(refund, response):
     """Verify the related payment of a refund."""
     response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
@@ -133,29 +100,6 @@ def test_create_payment_refund(payment, response):
     refund = payment.refunds.create(data)
     assert isinstance(refund, Refund)
     assert refund.id == REFUND_ID
-
-
-@pytest.mark.skip(reason="Obsoleted by test_get_payment_refund")
-def test_get_single_refund_on_payment_object(client, response):
-    """Retrieve a payment refund of a payment."""
-    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
-    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/refunds/{REFUND_ID}", "refund_single")
-
-    payment = client.payments.get(PAYMENT_ID)
-    refund = client.payment_refunds.on(payment).get(REFUND_ID)
-    assert isinstance(refund, Refund)
-    assert refund.id == REFUND_ID
-
-
-@pytest.mark.skip(reason="Obsoleted by test_get_payment_refund")
-def test_list_refunds_on_payment_object(client, response):
-    """Retrieve a list of payment refunds of a payment."""
-    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}", "payment_single")
-    response.get(f"https://api.mollie.com/v2/payments/{PAYMENT_ID}/refunds", "refunds_list")
-
-    payment = client.payments.get(PAYMENT_ID)
-    refunds = client.payment_refunds.on(payment).list()
-    assert_list_object(refunds, Refund)
 
 
 def test_cancel_payment_refund(payment, response):


### PR DESCRIPTION
Resolves #273 

Note: when overriding an enabled `testmode` for a single call (see the `test_override_testmode` test), we're sending `testmode=false` in stead of leaving the parameter out. I tested this (using [mollie-cli](https://pypi.org/project/mollie-cli/)) on a few endpoints, and it was accepted on all of them.