### PR TITLE
Add type annotations marker

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,13 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.7", "pypy-3.9"]
-        coverage_fail_under: [90]
-        include:
-          # https://github.com/nedbat/coveragepy/issues/1515
-          # https://foss.heptapod.net/pypy/pypy/-/issues/3876
-          - python_version: "pypy-3.8"
-            coverage_fail_under: 0
+        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.7", "pypy-3.8", "pypy-3.9"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -33,7 +27,7 @@ jobs:
           python -m pip install -r test_requirements.txt
 
       - name: Run unittests
-        run: python -m pytest --cov-fail-under=${{ matrix.coverage_fail_under }}
+        run: python -m pytest --cov-fail-under=90
 
       - name: Verify dependencies
         run: python -m safety check

--- a/mollie/api/version.py
+++ b/mollie/api/version.py
@@ -4,4 +4,4 @@
 # processed by python imports and by regular expressions. The version is defined as a string in the
 # regular semantic versioning scheme (major, minor, patch) as defined by PEP 440.
 
-VERSION = "3.0.1"
+VERSION = "3.1.0"

--- a/mollie/py.typed
+++ b/mollie/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(),
     include_package_data=True,
+    package_data={
+        "mollie": ["py.typed"],
+    },
     description="Mollie API client for Python",
     author="Mollie B.V.",
     author_email="info@mollie.com",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -9,3 +9,4 @@ mypy; platform_python_implementation != "PyPy"
 responses>=0.17.0
 safety
 types-requests
+coverage>=7.0.2


### PR DESCRIPTION
We need this to actually make use of the declared types when type-checking downstream packages.