### PR TITLE
Deprecate the 'Submit onboarding data' endpoint

### DIFF
--- a/mollie/api/resources/onboarding.py
+++ b/mollie/api/resources/onboarding.py
@@ -1,6 +1,7 @@
+import warnings
 from typing import Any, Dict
 
-from ..error import IdentifierError
+from ..error import APIDeprecationWarning, IdentifierError
 from ..objects.onboarding import Onboarding as OnboardingObject
 from .base import ResourceGetMixin
 
@@ -21,6 +22,12 @@ class Onboarding(ResourceGetMixin):
         return super().get(resource_id, **params)
 
     def create(self, data: Dict[str, Any], **params: Any) -> OnboardingObject:
+        warnings.warn(
+            "Submission of onboarding data is deprecated, see "
+            "https://docs.mollie.com/reference/v2/onboarding-api/submit-onboarding-data",
+            APIDeprecationWarning,
+        )
+
         resource_path = self.get_resource_path()
         path = f"{resource_path}/me"
         result = self.perform_api_call(self.REST_CREATE, path, data, params)

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mollie.api.error import IdentifierError
+from mollie.api.error import APIDeprecationWarning, IdentifierError
 from mollie.api.objects.onboarding import Onboarding
 from mollie.api.objects.organization import Organization
 
@@ -32,6 +32,7 @@ def test_get_onboarding_invalid_id(oauth_client):
     assert str(excinfo.value) == "Invalid onboarding ID: 'invalid'. The onboarding ID should be 'me'."
 
 
+@pytest.mark.filterwarnings("ignore:Submission of onboarding data is deprecated")
 def test_create_onboarding(oauth_client, response):
     """Create onboarding."""
     response.post("https://api.mollie.com/v2/onboarding/me", "empty", 204)
@@ -40,6 +41,14 @@ def test_create_onboarding(oauth_client, response):
 
     onboarding = oauth_client.onboarding.create(data)
     assert isinstance(onboarding, Onboarding)
+
+
+def test_create_onboarding_is_deprecated(oauth_client, response):
+    response.post("https://api.mollie.com/v2/onboarding/me", "empty", 204)
+
+    data = {"profile": {"categoryCode": "6012"}}
+    with pytest.warns(APIDeprecationWarning, match="Submission of onboarding data is deprecated"):
+        oauth_client.onboarding.create(data)
 
 
 def test_onboarding_get_organization(oauth_client, response):


### PR DESCRIPTION
Mollie has decided to move a different mechanism for onboarding, this endpoint will continue to work but is deprecated.

As per the [changelog](https://docs.mollie.com/changelog/v2/changelog#may-2023) and the [endpoint docs](https://docs.mollie.com/reference/v2/onboarding-api/submit-onboarding-data) 