### PR TITLE
Test with Python 3.12

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11", "pypy-3.9", "pypy-3.10"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.9", "pypy-3.10"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Note: Flake8/pycodestyle has several issues with Python3.12, all related to the fact that in Python3.12, f-strings can be tokenized. We just need to wait for another release.