### PR TITLE
Refactor regular expressions that extract identifiers from URLs

### DIFF
--- a/mollie/api/objects/chargeback.py
+++ b/mollie/api/objects/chargeback.py
@@ -49,7 +49,7 @@ class Chargeback(ObjectBase):
         if not url:
             return None
 
-        match = re.findall(r"/settlements/(stl_\w+)$", url)
+        match = re.findall(r"/settlements/(stl_[^/]+)/?$", url)
         if match:
             return match[0]
 

--- a/mollie/api/objects/subscription.py
+++ b/mollie/api/objects/subscription.py
@@ -120,7 +120,8 @@ class Subscription(ObjectBase):
         option is to extract it from the link.
         """
         url = self._get_link("customer")
-        matches = re.findall(r"/customers/(cst_\w+)", url)
+
+        matches = re.findall(r"/customers/(cst_[^/]+)/?$", url)
         if matches:
             return matches[0]
 

--- a/mollie/api/resources/base.py
+++ b/mollie/api/resources/base.py
@@ -44,7 +44,6 @@ class ResourceBase:
         params: Optional[Dict[str, Any]] = None,
         idempotency_key: str = "",
     ) -> Dict[str, Any]:
-
         resp = self.client.perform_http_call(http_method, path, data, params, idempotency_key)
         if "application/hal+json" in resp.headers.get("Content-Type", ""):
             # set the content type according to the media type definition


### PR DESCRIPTION
There has been mention of API identifiers that contain a `.` (dot) character, see https://github.com/mollie/magento2/issues/669

Just to be sure, we refactor these regular expressions so that we won't run into the same issue in the future. We are now allowing any character in the identifier, we handle termination using either the end of the regex, or a slash which would indicate a new subpart of the URL.
