### PR TITLE
Allow a longer bank reference

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,9 +2,10 @@ name: Run tests
 
 on:
   push:
-  workflow_call:
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_call:
 
 jobs:
   tests:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.9", "pypy-3.10"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9", "pypy-3.10"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/mollie/api/resources/balances.py
+++ b/mollie/api/resources/balances.py
@@ -42,7 +42,6 @@ class Balances(ResourceGetMixin, ResourceListMixin):
 
 
 class BalanceReports(ResourceBase):
-
     _balance: "Balance"
 
     def __init__(self, client: "Client", balance: "Balance") -> None:

--- a/mollie/api/resources/settlements.py
+++ b/mollie/api/resources/settlements.py
@@ -11,11 +11,11 @@ class Settlements(ResourceGetMixin, ResourceListMixin):
     RESOURCE_ID_PREFIX: str = "stl_"
 
     # According to Mollie, the bank reference is formatted as:
-    # - The Mollie customer ID, 4 to 7 digits.
+    # - The Mollie merchant ID, 4 to 8 digits, might grow when the number of merchants increases
     # - The year and month, 4 digits
     # - The sequence number of the settlement in that month, 2 digits
     # The components are separated by a dot.
-    BANK_REFERENCE_REGEX: Pattern[str] = re.compile(r"^\d{4,7}\.\d{4}\.\d{2}$", re.ASCII)
+    BANK_REFERENCE_REGEX: Pattern[str] = re.compile(r"^\d{4,}\.\d{4}\.\d{2}$", re.ASCII)
 
     def get_resource_object(self, result: dict) -> Settlement:
         return Settlement(result, self.client)

--- a/tests/test_settlements.py
+++ b/tests/test_settlements.py
@@ -10,7 +10,9 @@ from .utils import assert_list_object
 
 SETTLEMENT_ID = "stl_jDk30akdN"
 INVOICE_ID = "inv_xBEbP9rvAq"
-BANK_REFERENCE = "1234567.1804.03"
+BANK_REFERENCE = BANK_REFERENCE_SHORT = "1234.1804.03"
+BANK_REFERENCE_LONG = "01234567.1804.03"
+BANK_REFERENCE_FUTURE = "1234567890.1804.03"
 
 
 def test_list_settlements(oauth_client, response):
@@ -62,10 +64,18 @@ def test_settlement_get_open(oauth_client, response):
     assert isinstance(settlement, Settlement)
 
 
-def test_get_settlement_by_bank_reference(oauth_client, response):
-    response.get(f"https://api.mollie.com/v2/settlements/{BANK_REFERENCE}", "settlement_single")
+@pytest.mark.parametrize(
+    "bank_reference",
+    [
+        BANK_REFERENCE_SHORT,
+        BANK_REFERENCE_LONG,
+        BANK_REFERENCE_FUTURE,
+    ],
+)
+def test_get_settlement_by_bank_reference(oauth_client, response, bank_reference):
+    response.get(f"https://api.mollie.com/v2/settlements/{bank_reference}", "settlement_single")
 
-    settlement = oauth_client.settlements.get(BANK_REFERENCE)
+    settlement = oauth_client.settlements.get(bank_reference)
     assert isinstance(settlement, Settlement)
 
 


### PR DESCRIPTION
Mollie merchant IDs are now longer.

Related to #335 