### PR TITLE
setup.py: do not install tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     license="BSD",
     long_description=get_long_description(),
     long_description_content_type="text/markdown",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     package_data={
         "mollie": ["py.typed"],


### PR DESCRIPTION
Tests should not be part of the install image

Issue found by QA warning in Gentoo Linux: https://projects.gentoo.org/python/guide/qawarn.html#stray-top-level-files-in-site-packages