### PR TITLE
Use upload-artifact v4 since v3 is not compatible with download-artifact v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
     needs: pre-build-checks
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -32,7 +32,7 @@ jobs:
         run: python -m build
 
       - name: Save artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: 
           name: packages-${{ github.ref_name }}
           path: dist/*


### PR DESCRIPTION
Recently, dependabot upgraded download-artifact to v4 https://github.com/mollie/mollie-api-python/pull/365.

This is causing issues when publishing the package to pypi, because this download-artifact version is incompatible with upload-artifact v3. (https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md#which-versions-of-the-artifacts-packages-are-compatible)

This PR upgrades upload-artifact to v4, as well as the checkout action.

