### PR TITLE
Add support for PaymentLinkPayments resource

### DIFF
--- a/mollie/api/objects/payment_link.py
+++ b/mollie/api/objects/payment_link.py
@@ -69,3 +69,9 @@ class PaymentLink(ObjectBase):
 
     def has_expiration_date(self):
         return self.expires_at is not None
+
+    @property
+    def payments(self):
+        from ..resources import PaymentLinkPayments
+
+        return PaymentLinkPayments(self.client, self)

--- a/mollie/api/resources/payments.py
+++ b/mollie/api/resources/payments.py
@@ -4,6 +4,7 @@ from ..objects.customer import Customer
 from ..objects.list import PaginationList
 from ..objects.order import Order
 from ..objects.payment import Payment
+from ..objects.payment_link import PaymentLink
 from ..objects.profile import Profile
 from ..objects.subscription import Subscription
 from .base import (
@@ -26,6 +27,7 @@ __all__ = [
     "ProfilePayments",
     "SettlementPayments",
     "SubscriptionPayments",
+    "PaymentLinkPayments",
 ]
 
 
@@ -157,3 +159,16 @@ class ProfilePayments(PaymentsBase):
         # Set the profileId in the query params
         params.update({"profileId": self._profile.id})
         return Payments(self.client).list(**params)
+
+
+class PaymentLinkPayments(PaymentsBase, ResourceListMixin):
+    """Resource handler for the `/payment_links/:payment_link_id:/payments` endpoint."""
+
+    _payment_link: "PaymentLink"
+
+    def __init__(self, client: "Client", payment_link: "PaymentLink") -> None:
+        self._payment_link = payment_link
+        super().__init__(client)
+
+    def get_resource_path(self) -> str:
+        return f"payment-links/{self._payment_link.id}/payments"

--- a/tests/test_payment_links_payments.py
+++ b/tests/test_payment_links_payments.py
@@ -1,0 +1,21 @@
+from mollie.api.objects.payment import Payment
+
+from .utils import assert_list_object
+
+PAYMENT_LINK_ID = "pl_4Y0eZitmBnQ6IDoMqZQKh"
+
+
+def test_list_customer_payments(oauth_client, response):
+    """Retrieve a list of payments related to a payment link id."""
+    response.get(
+        f"https://api.mollie.com/v2/payment-links/{PAYMENT_LINK_ID}",
+        "payment_link_single",
+    )
+    response.get(
+        f"https://api.mollie.com/v2/payment-links/{PAYMENT_LINK_ID}/payments",
+        "payments_list",
+    )
+
+    payment_link = oauth_client.payment_links.get(PAYMENT_LINK_ID)
+    payments = payment_link.payments.list()
+    assert_list_object(payments, Payment)


### PR DESCRIPTION
This PR add support for [Payment Link Payments](https://docs.mollie.com/reference/get-payment-link-payments).

The code itself was heavily inspired by the existing `SettlementPayments`.