### PR TITLE
Fix list slicing with a zero stop or negative indices

### DIFF
--- a/mollie/api/objects/list.py
+++ b/mollie/api/objects/list.py
@@ -42,9 +42,11 @@ class ListBase(ObjectBase, ABC):
             return self.object_type(item, self.client)
 
         if isinstance(key, slice):
-            _start = key.start or 0
-            _stop = key.stop or self["count"]
-            _step = key.step or 1
+            # slice.indices() correctly resolves None, negative and out-of-range
+            # bounds. The previous ``key.stop or self["count"]`` treated a stop
+            # of 0 as "unset", so e.g. ``obj_list[:0]`` returned the whole list
+            # instead of an empty one (and negative indices were mishandled).
+            _start, _stop, _step = key.indices(len(self))
             sliced_data = [self["_embedded"][object_name][x] for x in range(_start, _stop, _step)]
             # Now we mock a result based on the sliced data
             sliced_result = {

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -158,3 +158,9 @@ def test_list_supports_slice_sequences(client, response):
     slice_step_only = methods[::3]
     assert_list_object(slice_step_only, Method, 4), "Slicing with only a step value should be possible"
     assert [x.id for x in slice_step_only] == ["ideal", "bancontact", "kbc", "giftcard"]
+
+    slice_empty = methods[:0]
+    assert [x.id for x in slice_empty] == [], "A slice with a stop of 0 should be empty"
+
+    slice_negative = methods[-2:]
+    assert [x.id for x in slice_negative] == ["inghomepay", "giftcard"], "Negative slicing should be possible"


### PR DESCRIPTION
## Problem

`ListBase.__getitem__` resolves slice bounds like this:

```python
_start = key.start or 0
_stop = key.stop or self["count"]
_step = key.step or 1
```

Because `0` is falsy, `key.stop or self["count"]` treats a **stop of 0 as "unset"**. So a slice such as `obj_list[:0]` (conventionally empty) returns the **entire list**. Negative indices are also mishandled (e.g. `obj_list[-2:]` produces a wrong, over-long result), since raw negative bounds are passed straight to `range()`.

## Fix

Use `slice.indices(len(self))`, the standard way to normalise slice bounds — it correctly handles `None`, negative, and out-of-range start/stop/step. All previously-passing slices are unchanged.

## Tests

Extended `test_list_supports_slice_sequences` with a zero-stop case (`methods[:0]` → empty) and a negative case (`methods[-2:]` → last two). Both fail on `main` and pass with this change; the existing slice assertions continue to pass.